### PR TITLE
dev to stg - 11/30/2024

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+synonym.cfx filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,88 @@
+name: deploy-prod
+
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+        - info
+        - warning
+        - debug
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: main
+        lfs: true
+    - run: git lfs pull
+    - uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'corretto'
+        
+    - name: Run the Maven clean package
+      run: mvn clean package -DskipTests
+
+    - uses: actions/upload-artifact@master
+      with:
+        name: chemical-jar
+        path: ./target
+      
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          lfs: true
+      - run: git lfs pull
+      - uses: actions/download-artifact@master
+        with:
+          name: chemical-jar
+          path: ./target
+      - name: Deploy to cloud.gov
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          cf_username: ${{ secrets.CF_SERVICE_USERNAME }}
+          cf_password: ${{ secrets.CF_SERVICE_KEY }}
+          cf_org: epa-ccte
+          cf_space: prod
+          cf_command: push -f manifest-prod.yml --no-start
+          
+  bind-db-service:
+    runs-on: ubuntu-latest
+    needs: deploy
+    
+    steps:
+      - name: Bind app to DB service
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          cf_username: ${{ secrets.CF_SERVICE_USERNAME }}
+          cf_password: ${{ secrets.CF_SERVICE_KEY }}
+          cf_org: epa-ccte
+          cf_space: prod
+          cf_command: bind-service ccte-chemical-prod ccte-db-prod2
+          
+  restage:
+    runs-on: ubuntu-latest
+    needs: bind-db-service
+    
+    steps:
+      - name: Restage app
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          cf_username: ${{ secrets.CF_SERVICE_USERNAME }}
+          cf_password: ${{ secrets.CF_SERVICE_KEY }}
+          cf_org: epa-ccte
+          cf_space: prod
+          cf_command: restage ccte-chemical-prod

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,88 @@
+name: deploy-staging
+
+on:
+  workflow_dispatch:
+      inputs:
+        logLevel:
+          description: 'Log level'
+          required: true
+          default: 'warning'
+          type: choice
+          options:
+          - info
+          - warning
+          - debug
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: staging
+        lfs: true
+    - run: git lfs pull
+    - uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'corretto'
+        
+    - name: Run the Maven clean package
+      run: mvn clean package -DskipTests
+
+    - uses: actions/upload-artifact@master
+      with:
+        name: chemical-jar
+        path: ./target
+      
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: staging
+          lfs: true
+      - run: git lfs pull
+      - uses: actions/download-artifact@master
+        with:
+          name: chemical-jar
+          path: ./target
+      - name: Deploy to cloud.gov
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          cf_username: ${{ secrets.CF_STAGING_SERVICE_USERNAME }}
+          cf_password: ${{ secrets.CF_STAGING_SERVICE_KEY }}
+          cf_org: epa-ccte
+          cf_space: staging
+          cf_command: push -f manifest-stg.yml --no-start
+          
+  bind-db-service:
+    runs-on: ubuntu-latest
+    needs: deploy
+    
+    steps:
+      - name: Bind app to DB service
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          cf_username: ${{ secrets.CF_STAGING_SERVICE_USERNAME }}
+          cf_password: ${{ secrets.CF_STAGING_SERVICE_KEY }}
+          cf_org: epa-ccte
+          cf_space: staging
+          cf_command: bind-service ccte-chemical-stg ccte-db-prod2
+          
+  restage:
+    runs-on: ubuntu-latest
+    needs: bind-db-service
+    
+    steps:
+      - name: Restage app
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          cf_username: ${{ secrets.CF_STAGING_SERVICE_USERNAME }}
+          cf_password: ${{ secrets.CF_STAGING_SERVICE_KEY }}
+          cf_org: epa-ccte
+          cf_space: staging
+          cf_command: restage ccte-chemical-stg

--- a/.github/workflows/gh-packages-deployment.yml
+++ b/.github/workflows/gh-packages-deployment.yml
@@ -1,0 +1,38 @@
+name: GH Packages Deployment
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  maven-build-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK 1.17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+          cache: 'maven'
+          server-id: github # value of repository/id field of the pom.xml
+          server-username: GITHUB_USER_REF  # env variable name for username
+          server-password: GITHUB_TOKEN_REF # env variable name for GitHub Pers
+      - name: Maven Package
+        env:
+          GITHUB_USER_REF: USEPA
+          GITHUB_TOKEN_REF: ${{ secrets.GH_PACKAGE_REPO_PASSWORD }}
+        run: |
+          mvn clean package -DskipTests
+      - name: Deploy to Github Package Registry
+        env:
+          GITHUB_USER_REF: USEPA
+          GITHUB_TOKEN_REF: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mvn deploy -DskipTests

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,46 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+
+name: Maven Package
+
+on:
+  push:
+    branches: [ "dev"]
+    # Publish semver tags as releases.
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+        - info
+        - warning
+        - debug
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    - name: Publish to GitHub Packages Apache Maven
+      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/manifest-prod.yml
+++ b/manifest-prod.yml
@@ -6,7 +6,7 @@ applications:
       - route: api-ccte.epa.gov/chemical
 #      - route: ccte-api.app.cloud.gov/chemical
     memory: 2G
-    instances: 1
+    instances: 2
     random-route: false
     path: target/chemical.jar
     buildpacks:

--- a/manifest-stg.yml
+++ b/manifest-stg.yml
@@ -7,10 +7,14 @@ applications:
       #- route: ccte-api-s.app.cloud.gov/chemical
     memory: 2G
     instances: 1
+#    health-check-type: http
+#    health-check-http-endpoint: /health
     random-route: false
     path: target/chemical.jar
     buildpacks:
     - https://github.com/cloudfoundry/java-buildpack
+#    services:
+#      - ccte-db-prod2
     env:
       SPRING_PROFILES_ACTIVE: cloud,apikey,stg
       JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 17.+}}'

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>gov.epa.ccte.api</groupId>
 	<artifactId>chemical</artifactId>
-	<version>1</version>
+	<version>1.0.0</version>
 	<name>chemical</name>
 	<description>project for chemicals</description>
 	<properties>
@@ -18,8 +18,17 @@
 		<testcontainers.version>1.17.6</testcontainers.version>
 		<lombok.version>1.18.24</lombok.version>
 		<mapstruct.version>1.5.3.Final</mapstruct.version>
+        
 	</properties>
-
+	
+        <distributionManagement>
+        	<repository>
+            		<id>github</id>
+            		<name>GitHub OWNER Apache Maven Packages</name>
+            		<url>https://maven.pkg.github.com/USEPA/ccte-api-chemical</url>
+        	</repository>
+    	</distributionManagement>
+	
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -133,7 +142,7 @@
 	</dependencies>
 
 	<build>
-		<finalName>${project.artifactId}</finalName>
+		<finalName>${project.artifactId}-${project.version}</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>

--- a/src/main/java/gov/epa/ccte/api/chemical/config/ApiSecurityConfiguration.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/config/ApiSecurityConfiguration.java
@@ -2,7 +2,9 @@ package gov.epa.ccte.api.chemical.config;
 
 
 import gov.epa.ccte.api.chemical.domain.ApiKey;
+import gov.epa.ccte.api.chemical.domain.ApprovedHost;
 import gov.epa.ccte.api.chemical.repository.ApiKeyRepository;
+import gov.epa.ccte.api.chemical.repository.ApprovedHostRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,9 +20,11 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ApiSecurityConfiguration {
 
     private final ApiKeyRepository repository;
+    private final ApprovedHostRepository approvedHostRepository;
 
-    public ApiSecurityConfiguration(ApiKeyRepository repository) {
+    public ApiSecurityConfiguration(ApiKeyRepository repository, ApprovedHostRepository approvedHostRepository) {
         this.repository = repository;
+        this.approvedHostRepository = approvedHostRepository;
     }
 
     @Bean
@@ -28,6 +32,9 @@ public class ApiSecurityConfiguration {
         log.debug("*** start filling ApiKeyStore ***");
 
         ConcurrentHashMap<UUID, String> keyStore = new ConcurrentHashMap<>();
+
+        log.debug("*** start loading api keys ***");
+
 
         List<ApiKey> keys = repository.findAll();
 
@@ -40,25 +47,46 @@ public class ApiSecurityConfiguration {
     }
 
     @Bean
-    public ConcurrentHashMap<String, String> approvedOriginStore(){
-        log.debug("*** start filling approvedOriginStore ***");
-
+    public ConcurrentHashMap<String, String> approvedOriginStoreFromDB(){
+        log.debug("*** start loading approved hosts ***");
         ConcurrentHashMap<String, String> approvedOriginStore = new ConcurrentHashMap<>();
-        // make sure it is https even it is localhost
-        approvedOriginStore.put("https://localhost:3003", "https://localhost:3003");
-        approvedOriginStore.put("https://localhost:8888", "https://localhost:8888");
-        approvedOriginStore.put("http://localhost:3003", "http://localhost:3003");
-        approvedOriginStore.put("http://localhost:8888", "http://localhost:8888");
-        approvedOriginStore.put("https://ccte-ccd-dev.epa.gov", "https://ccte-ccd-dev.epa.gov");
-        approvedOriginStore.put("https://ccte-ccd-stg.epa.gov", "https://ccte-ccd-stg.epa.gov");
-        approvedOriginStore.put("https://ccte-ccd-prod.epa.gov", "https://ccte-ccd-prod.epa.gov");
-        approvedOriginStore.put("https://comptox.epa.gov", "https://comptox.epa.gov");
-        approvedOriginStore.put("https://ccte-api-s.app.cloud.gov", "https://ccte-api-s.app.cloud.gov");
-        approvedOriginStore.put("https://v2626umcth886.rtord.epa.gov:8888", "https://v2626umcth886.rtord.epa.gov:8888");
-        approvedOriginStore.put("https://comptoxstaging.rtpnc.epa.gov", "https://comptoxstaging.rtpnc.epa.gov");
 
-        log.info("*** {} urls are loaded. *** ", approvedOriginStore.size());
+        List<ApprovedHost> hosts = approvedHostRepository.findAll();
+
+        for(ApprovedHost host : hosts){
+            approvedOriginStore.put(host.getHostName(), host.getHostName());
+        }
+
+        log.info("*** {} hosts are loaded. *** ", approvedOriginStore.size());
 
         return approvedOriginStore;
     }
+
+//    @Bean
+//    public ConcurrentHashMap<String, String> approvedOriginStore(){
+//        log.debug("*** start filling approvedOriginStore ***");
+//
+//        ConcurrentHashMap<String, String> approvedOriginStore = new ConcurrentHashMap<>();
+//        // make sure it is https even it is localhost
+//        approvedOriginStore.put("https://localhost:3003", "https://localhost:3003");
+//        approvedOriginStore.put("https://localhost:8888", "https://localhost:8888");
+//        approvedOriginStore.put("http://localhost:3003", "http://localhost:3003");
+//        approvedOriginStore.put("http://localhost:8888", "http://localhost:8888");
+//        approvedOriginStore.put("https://ccte-ccd-dev.epa.gov", "https://ccte-ccd-dev.epa.gov");
+//        approvedOriginStore.put("https://ccte-ccd-stg.epa.gov", "https://ccte-ccd-stg.epa.gov");
+//        approvedOriginStore.put("https://ccte-ccd-prod.epa.gov", "https://ccte-ccd-prod.epa.gov");
+//        approvedOriginStore.put("https://ccte-ccd.epa.gov", "https://ccte-ccd.epa.gov");
+//        approvedOriginStore.put("https://comptox.epa.gov", "https://comptox.epa.gov");
+//        approvedOriginStore.put("https://ccte-api-s.app.cloud.gov", "https://ccte-api-s.app.cloud.gov");
+//        approvedOriginStore.put("https://v2626umcth886.rtord.epa.gov:8888", "https://v2626umcth886.rtord.epa.gov:8888");
+//        approvedOriginStore.put("https://v2626umcth877.rtord.epa.gov:8001", "https://v2626umcth877.rtord.epa.gov:8001");
+//        approvedOriginStore.put("https://v2626umcth878.rtord.epa.gov:8001", "https://v2626umcth878.rtord.epa.gov:8001");
+//        approvedOriginStore.put("https://comptoxstaging.rtpnc.epa.gov", "https://comptoxstaging.rtpnc.epa.gov");
+//        approvedOriginStore.put("https://v2626umcth875.rtord.epa.gov:8001", "https://v2626umcth875.rtord.epa.gov:8001");
+//
+//
+//        log.info("*** {} urls are loaded. *** ", approvedOriginStore.size());
+//
+//        return approvedOriginStore;
+//    }
 }

--- a/src/main/java/gov/epa/ccte/api/chemical/domain/ApprovedHost.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/domain/ApprovedHost.java
@@ -1,0 +1,21 @@
+package gov.epa.ccte.api.chemical.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "approved_hosts", schema = "app")
+public class ApprovedHost {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "approved_hosts_id_gen")
+    @SequenceGenerator(name = "approved_hosts_id_gen", sequenceName = "approved_hosts_id_seq", allocationSize = 1)
+    @Column(name = "id", nullable = false)
+    private Integer id;
+
+    @Column(name = "host_name", length = Integer.MAX_VALUE)
+    private String hostName;
+
+}

--- a/src/main/java/gov/epa/ccte/api/chemical/domain/ChemicalSynonym.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/domain/ChemicalSynonym.java
@@ -10,10 +10,12 @@ import lombok.Setter;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+import java.time.OffsetDateTime;
+
 @Getter
 @Setter
 @Entity
-@Table(name = "chemical_synonym", schema = "ms")
+@Table(name = "v_chemical_snonyms", schema = "ch")
 public class ChemicalSynonym {
     @Id
     @Size(max = 45)
@@ -28,24 +30,30 @@ public class ChemicalSynonym {
     @JdbcTypeCode(SqlTypes.LONGVARCHAR)
     private String validSynonym;
 
-    @Column(name = "good_synonyms")
+    @Column(name = "good_synonym")
     @JdbcTypeCode(SqlTypes.LONGVARCHAR)
     private String goodSynonyms;
 
-    @Column(name = "delete_synonyms")
+    @Column(name = "deleted_synonym")
     @JdbcTypeCode(SqlTypes.LONGVARCHAR)
     private String deleteSynonyms;
 
-    @Column(name = "other_synonyms")
+    @Column(name = "other_synonym")
     @JdbcTypeCode(SqlTypes.LONGVARCHAR)
     private String otherSynonyms;
 
-    @Column(name = "beilstein_synonyms")
+    @Column(name = "beilstein_synonym")
     @JdbcTypeCode(SqlTypes.LONGVARCHAR)
     private String beilsteinSynonyms;
 
-    @Column(name = "alternate_synonyms")
+    @Column(name = "alternate_synonym")
     @JdbcTypeCode(SqlTypes.LONGVARCHAR)
     private String alternateSynonyms;
+
+    @Column(name = "is_public")
+    private Boolean isPublic;
+
+    @Column(name = "import_date")
+    private OffsetDateTime importDate;
 
 }

--- a/src/main/java/gov/epa/ccte/api/chemical/domain/ExtraData.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/domain/ExtraData.java
@@ -1,0 +1,38 @@
+package gov.epa.ccte.api.chemical.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@Entity
+@Table(name = "v_extra_data", schema = "ch")
+public class ExtraData {
+    @Id
+    @Size(max = 45)
+    @Column(name = "dtxsid", length = 45)
+    private String dtxsid;
+
+    @Size(max = 45)
+    @Column(name = "cid", length = 45)
+    private Integer dtxcid;
+
+    @Size(max = 255)
+    @Column(name = "refs")
+    private Integer refs;
+
+    @Column(name = "google_patent")
+    private Integer googlePatent;
+
+    @Column(name = "literature")
+    private Integer literature;
+
+    @Column(name = "pubmed")
+    private Integer pubmed;
+}

--- a/src/main/java/gov/epa/ccte/api/chemical/projection/chemicaldetail/CcdChemicalDetails.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/projection/chemicaldetail/CcdChemicalDetails.java
@@ -25,6 +25,8 @@ public interface CcdChemicalDetails extends ChemicalDetailBase {
 
     Double getMonoisotopicMass();
 
+    Double getAverageMass();
+
     Double getPercentAssays();
 
     Integer getPubchemCount();

--- a/src/main/java/gov/epa/ccte/api/chemical/projection/chemicaldetail/ChemicalDetailProjection.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/projection/chemicaldetail/ChemicalDetailProjection.java
@@ -4,5 +4,5 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(enumAsRef = true,name = "ChemicalDetailProjection", description = "Projection options for chemical details APIs ")
 public enum ChemicalDetailProjection {
-    chemicaldetailstandard, chemicalidentifier, chemicalstructure, ntatoolkit, ccdchemicaldetails,chemicaldetailall
+    chemicaldetailstandard, chemicalidentifier, chemicalstructure, ntatoolkit, ccdchemicaldetails,chemicaldetailall,compact
 }

--- a/src/main/java/gov/epa/ccte/api/chemical/projection/chemicaldetail/ChemicalDetailStandard2.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/projection/chemicaldetail/ChemicalDetailStandard2.java
@@ -1,0 +1,32 @@
+package gov.epa.ccte.api.chemical.projection.chemicaldetail;
+
+/**
+ * Projection for {@link gov.epa.ccte.api.chemical.domain.ChemicalDetail}
+ */
+public interface ChemicalDetailStandard2 {
+    Long getId();
+
+    String getDtxsid();
+
+    String getCasrn();
+
+    String getPreferredName();
+
+    String getMolFormula();
+
+    Double getMonoisotopicMass();
+
+    Integer getQcLevel();
+
+    String getQcLevelDesc();
+
+    String getIupacName();
+
+    String getSmiles();
+
+    String getInchiString();
+
+    Double getAverageMass();
+
+    String getInchikey();
+}

--- a/src/main/java/gov/epa/ccte/api/chemical/projection/chemicaldetail/Compact.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/projection/chemicaldetail/Compact.java
@@ -1,0 +1,15 @@
+package gov.epa.ccte.api.chemical.projection.chemicaldetail;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Projection for {@link gov.epa.ccte.api.chemical.domain.ChemicalDetail}
+ */
+@Schema(name = "compact", description = "Minimum attributes for chemical details APIs")
+public interface Compact extends ChemicalDetailBase {
+    String getDtxsid();
+
+    String getCasrn();
+
+    String getPreferredName();
+}

--- a/src/main/java/gov/epa/ccte/api/chemical/projection/chemicallist/ChemicalListAll.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/projection/chemicallist/ChemicalListAll.java
@@ -1,6 +1,10 @@
 package gov.epa.ccte.api.chemical.projection.chemicallist;
 
+import org.springframework.beans.factory.annotation.Value;
+
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Projection for {@link gov.epa.ccte.api.chemical.domain.ChemicalList}
@@ -25,4 +29,25 @@ public interface ChemicalListAll extends ChemicalListBase{
     Instant getCreatedAt();
 
     Instant getUpdatedAt();
+
+//    @Value("#{DateTimeFormatter.ofPattern('dd.MM.yyyy').withZone(ZoneId.systemDefault()).format(target.createdAt)}")
+//    Instant getCreateDateAt();
+
+//    default String getCreatedAtDate(){
+//        try{
+//            return DateTimeFormatter.ofPattern("yyyy.MM.dd").withZone(ZoneId.systemDefault()).format(getCreatedAt());
+//        }catch (Exception e){
+//            System.out.println(e.toString());
+//            return "";
+//        }
+//    }
+//
+//    default String getUpdatedAtDate(){
+//        try{
+//            return DateTimeFormatter.ofPattern("yyyy.MM.dd").withZone(ZoneId.systemDefault()).format(getUpdatedAt());
+//        }catch (Exception e){
+//            System.out.println(e.toString());
+//            return "";
+//        }
+//    }
 }

--- a/src/main/java/gov/epa/ccte/api/chemical/projection/chemicallist/ChemicalListProjection.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/projection/chemicallist/ChemicalListProjection.java
@@ -4,5 +4,5 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(enumAsRef = true,name = "ChemicalListProjection", description = "Projection options for chemical List APIs ")
 public enum ChemicalListProjection {
-    chemicallistall, chemicallistwithdtxsids, chemicallistname
+    chemicallistall, chemicallistwithdtxsids, chemicallistname, ccdchemicaldetaillists
 }

--- a/src/main/java/gov/epa/ccte/api/chemical/repository/ApprovedHostRepository.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/repository/ApprovedHostRepository.java
@@ -1,0 +1,9 @@
+package gov.epa.ccte.api.chemical.repository;
+
+import gov.epa.ccte.api.chemical.domain.ApprovedHost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource(exported = false)
+public interface ApprovedHostRepository extends JpaRepository<ApprovedHost, Integer> {
+}

--- a/src/main/java/gov/epa/ccte/api/chemical/repository/ChemicalDetailRepository.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/repository/ChemicalDetailRepository.java
@@ -1,6 +1,8 @@
 package gov.epa.ccte.api.chemical.repository;
 
 import gov.epa.ccte.api.chemical.domain.ChemicalDetail;
+import gov.epa.ccte.api.chemical.projection.chemicaldetail.ChemicalDetailStandard2;
+import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,6 +16,7 @@ import java.util.Optional;
 @SuppressWarnings("unused")
 @RepositoryRestResource(collectionResourceRel = "chemicalDetails", path = "chemical-details", itemResourceRel = "chemicalDetail", exported = false)
 public interface ChemicalDetailRepository extends JpaRepository<ChemicalDetail, Long> {
+
 
     // Single chemical search
     @Transactional(readOnly = true)
@@ -33,9 +36,15 @@ public interface ChemicalDetailRepository extends JpaRepository<ChemicalDetail, 
 
     @Transactional(readOnly = true)
     <T>
-    List<T> findByDtxcidInOrderByDtxcidAsc(String[] dtxsid, Class<T> type);
+    List<T> findByDtxcidInOrderByDtxcidAsc(String[] dtxcid, Class<T> type);
 
     // Query for chemical files
+
+    @Transactional(readOnly = true)
+    @RestResource(path = "by-gsid",rel = "find-by-gsid",exported = true)
+    @Query(value = "select c.molImage from ChemicalDetail c where c.genericSubstanceId = :gsid")
+    byte[] getMolImageForGsid(@Param("gsid") String gsid);
+
     @Transactional(readOnly = true)
     @RestResource(path = "by-dtxsid",rel = "find-by-dtxsid",exported = true)
     @Query(value = "select c.molImage from ChemicalDetail c where c.dtxsid = :dtxsid")
@@ -45,6 +54,11 @@ public interface ChemicalDetailRepository extends JpaRepository<ChemicalDetail, 
     @RestResource(path = "by-dtxcid",rel = "find-by-dtxcid",exported = true)
     @Query(value = "select c.molImage from ChemicalDetail c where c.dtxcid = :dtxcid")
     byte[] getMolImageForDtxcid(@Param("dtxcid") String dtxcid);
+
+    @Transactional(readOnly = true)
+    @RestResource(path = "by-gsid",rel = "find-by-gsid",exported = true)
+    @Query(value = "select c.molFile from ChemicalDetail c where c.genericSubstanceId = :gsid")
+    Optional<String> getMolFileForGsid(@Param("gsid") String gsid);
 
     @Transactional(readOnly = true)
     @RestResource(path = "by-dtxsid",rel = "find-by-dtxsid",exported = true)
@@ -65,5 +79,12 @@ public interface ChemicalDetailRepository extends JpaRepository<ChemicalDetail, 
     @RestResource(path = "by-dtxcid",rel = "find-by-dtxcid",exported = true)
     @Query(value = "select c.mrvFile from ChemicalDetail c where c.dtxcid = :dtxcid")
     Optional<String> getMrvFileForDtxcid(@Param("dtxcid") String dtxcid);
+
+    @Transactional(readOnly = true)
+    @Query(value = "select c.inchikey from ChemicalDetail c where c.dtxsid = :dtxsid")
+    Optional<String> getInchikeyForDtxsid(@Param("dtxsid") String dtxsid);
+
+    @Transactional(readOnly = true)
+    List<ChemicalDetailStandard2> findByIdGreaterThanAndDtxsidNotNull(Long id, Limit limit);
 
 }

--- a/src/main/java/gov/epa/ccte/api/chemical/repository/ChemicalListChemicalRepository.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/repository/ChemicalListChemicalRepository.java
@@ -1,6 +1,8 @@
 package gov.epa.ccte.api.chemical.repository;
 
 import gov.epa.ccte.api.chemical.domain.ChemicalListChemical;
+import gov.epa.ccte.api.chemical.web.rest.GhsLinkResponse;
+import gov.epa.ccte.api.chemical.web.rest.WikipediaLinkResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
@@ -10,6 +12,8 @@ import java.util.List;
 
 @RepositoryRestResource(exported = false)
 public interface ChemicalListChemicalRepository extends JpaRepository<ChemicalListChemical, Long> {
+
+
 
     @Query("select distinct c.listName from ChemicalListChemical c join ChemicalList l on c.listId = l.id and c.dtxsid = :dtxsid and l.visibility = :visibility ")
     List<String> getListNames(String dtxsid, String visibility);
@@ -32,5 +36,20 @@ public interface ChemicalListChemicalRepository extends JpaRepository<ChemicalLi
     @Query(nativeQuery = true,
     value = " select dtxsid || '-' || list_name from ch.v_chemical_list_chemicals where dtxsid in (:dtxsids) and list_name in (:chemicalLists) ")
     List<String> chemicalListsAndDtxsids( List<String> chemicalLists, List<String> dtxsids);
+
+
+    @Query("select new gov.epa.ccte.api.chemical.web.rest.GhsLinkResponse(d.dtxsid, " +
+            "case when l.dtxsid is null then false else true end, " +
+            "case when l.dtxsid is null then null else 'https://pubchem.ncbi.nlm.nih.gov/compound/' ||  d.inchikey || '#section=GHS-Classification' end ) " +
+            "from  ChemicalDetail d left join ChemicalListChemical l on l.dtxsid = d.dtxsid and l.listName = 'LCSSPUBCHEM' where d.dtxsid in (?1)")
+    List<GhsLinkResponse> isGhsLinkExists(String[] dtxsid);
+
+    @Query("select l.dtxsid from ChemicalListChemical l where upper(l.listName) = upper(:list) and l.isPublic = true ")
+    List<String> getDtxsids(String list);
+
+    @Query("select new gov.epa.ccte.api.chemical.web.rest.WikipediaLinkResponse(d.dtxsid, " +
+            "case when l.dtxsid is null then null else 'https://en.wikipedia.org/wiki/' ||  d.inchikey || '#section=wiki-Classification' end ) " +
+            "from  ChemicalDetail d left join ChemicalListChemical l on l.dtxsid = d.dtxsid and l.listName = 'WIKIPEDIA' where d.dtxsid in (?1)")
+    List<WikipediaLinkResponse> isWikipediaLinkExists(String[] dtxsid);
 
 }

--- a/src/main/java/gov/epa/ccte/api/chemical/repository/ChemicalListRepository.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/repository/ChemicalListRepository.java
@@ -6,9 +6,9 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
-import org.springframework.data.rest.core.annotation.RestResource;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,6 +25,10 @@ public interface ChemicalListRepository extends JpaRepository<ChemicalList, Inte
     @Transactional(readOnly = true)
     <T>
     Optional<T> findByListNameIgnoreCaseAndVisibilityAndIsVisible(String listName, String visibility, Boolean isVisible, Class<T> type);
+
+    @Transactional(readOnly = true)
+    <T>
+    List<T> findByListNameInIgnoreCaseAndVisibilityAndIsVisibleOrderByListNameAsc(Collection<String> listNames, String visibility, Boolean isVisible, Class<T> type);
 
 
     @Transactional(readOnly = true)

--- a/src/main/java/gov/epa/ccte/api/chemical/repository/ChemicalSearchRepository.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/repository/ChemicalSearchRepository.java
@@ -2,6 +2,7 @@ package gov.epa.ccte.api.chemical.repository;
 
 import gov.epa.ccte.api.chemical.domain.ChemicalSearch;
 import gov.epa.ccte.api.chemical.projection.search.CcdChemicalSearchResult;
+import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,9 +15,7 @@ import java.util.List;
 @RepositoryRestResource(exported = false)
 public interface ChemicalSearchRepository extends JpaRepository<ChemicalSearch, Long> {
 
-    <T> List<T> findByModifiedValueStartingWithAndSearchNameInOrderByRankAscSearchValue(String word, List<String> searchWords, Class<T> type);
-
-    <T> List<T> findTop20ByModifiedValueStartsWithAndSearchNameInOrderByRankAscSearchValueAsc(String modifiedValue, Collection<String> searchNames, Class<T> type);
+    <T> List<T> findByModifiedValueStartingWithAndSearchNameInOrderByRankAscSearchValue(String word, List<String> searchWords, Limit limit, Class<T> type);
 
     <T> List<T> findByModifiedValueOrderByRankAsc(String word, Class<T> type);
 
@@ -24,8 +23,9 @@ public interface ChemicalSearchRepository extends JpaRepository<ChemicalSearch, 
 
     <T> List<T> findByModifiedValueInAndSearchNameInOrderByRankAsc(Collection<String> modifiedValues, Collection<String> searchNames, Class<T> type);
 
+    <T> List<T> findByModifiedValueContainsAndSearchNameInOrderByRankAscDtxsidAsc(String modifiedValue, List<String> searchWords, Limit limit, Class<T> type);
 
-    <T> List<T> findByModifiedValueContainsOrderByRankAscDtxsid(String word, Class<T> type);
+    <T> List<T> findByModifiedValueContainsOrderByRankAscDtxsid(String word, Limit limit, Class<T> type);
 
     // Query for inchikey suggestion
     @Query("select distinct c.searchValue from ChemicalSearch c where c.modifiedValue like concat(:inchikey, '%')")
@@ -50,5 +50,6 @@ public interface ChemicalSearchRepository extends JpaRepository<ChemicalSearch, 
     @Query(value = "select distinct ms_ready_dtxsid from ch.v_msready_search where monoisotopic_mass between :start and :end and substance_public is true", nativeQuery = true)
 
     List<String> searchMsReadyMass(Double start, Double end);
+
 
 }

--- a/src/main/java/gov/epa/ccte/api/chemical/repository/ChemicalSynonymRepository.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/repository/ChemicalSynonymRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.data.rest.core.annotation.RestResource;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @RepositoryRestResource(collectionResourceRel = "chemicalSynonym", path = "chemical-synonym", itemResourceRel = "chemicalSynonym", exported = false)
@@ -14,5 +16,9 @@ public interface ChemicalSynonymRepository extends JpaRepository<ChemicalSynonym
     @RestResource(rel = "findByDtxsid", path = "by-dtxsid", exported = false)
     <T>
     Optional<T> findByDtxsid(String dtxsid, Class<T> type);
+
+    <T> Optional<T> findByDtxsidAndIsPublic(String dtxsid, Boolean isPublic, Class<T> type);
+
+    <T> List<T> findByDtxsidInAndIsPublicOrderByDtxsidAsc(Collection<String> dtxsids, Boolean isPublic, Class<T> type);
 
 }

--- a/src/main/java/gov/epa/ccte/api/chemical/repository/ExtraDataRepository.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/repository/ExtraDataRepository.java
@@ -1,0 +1,18 @@
+package gov.epa.ccte.api.chemical.repository;
+
+import gov.epa.ccte.api.chemical.domain.ExtraData;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RepositoryRestResource(exported = false)
+public interface ExtraDataRepository extends JpaRepository<ExtraData, String> {
+    @Transactional(readOnly = true)
+    <T> List<T> findByDtxsid(String dtxsid, Class<T> type);
+
+    @Transactional(readOnly = true)
+    <T> List<T> findByDtxsidInOrderByDtxsidAsc(String[] dtxsids, Class<T> type);
+
+}

--- a/src/main/java/gov/epa/ccte/api/chemical/security/ApiKeyRequestFilter.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/security/ApiKeyRequestFilter.java
@@ -136,7 +136,7 @@ public class ApiKeyRequestFilter extends GenericFilterBean {
         log.debug("method = {}, origin = {}, x-forwarded-server = {}, host = {}, referer ={}, refererdHost = {}, path={} ",method, origin, server, host, referer, refererdHost, path);
 
         // if chemical/file path - allow access to images without any api key
-        if(path.contains("/chemical/file/")){
+        if(path.contains("/chemical/file/") || path.contains("/chemical/health")){
             log.debug("skipping api-key check");
             return false;
         }

--- a/src/main/java/gov/epa/ccte/api/chemical/service/IndigoService.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/service/IndigoService.java
@@ -68,13 +68,27 @@ public class IndigoService {
         }
     }
 
-    public String mol2inchikey(String mol){
+    public String mol2inchi(String mol){
         try {
             Indigo indigo = getIndigo();
             IndigoObject m = indigo.loadMolecule(mol);
             IndigoInchi indigoInchi = new IndigoInchi(indigo);
             String inchi = indigoInchi.getInchi(m);
             return inchi;
+        } catch ( IndigoException ex ) {
+            log.error("mol2smiles {}: {}", mol, ex.getMessage());
+            return null;
+        }
+    }
+
+    public String mol2inchikey(String mol){
+        try {
+            Indigo indigo = getIndigo();
+            IndigoObject m = indigo.loadMolecule(mol);
+            IndigoInchi indigoInchi = new IndigoInchi(indigo);
+            String inchi = indigoInchi.getInchi(m);
+            String inchikey = indigoInchi.getInchiKey(inchi);
+            return inchikey;
         } catch ( IndigoException ex ) {
             log.error("mol2smiles {}: {}", mol, ex.getMessage());
             return null;

--- a/src/main/java/gov/epa/ccte/api/chemical/web/rest/ChemicalDetailResource.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/web/rest/ChemicalDetailResource.java
@@ -3,8 +3,9 @@ package gov.epa.ccte.api.chemical.web.rest;
 import gov.epa.ccte.api.chemical.domain.ChemicalDetail;
 import gov.epa.ccte.api.chemical.projection.chemicaldetail.*;
 import gov.epa.ccte.api.chemical.service.ChemicalDetailService;
-import gov.epa.ccte.api.chemical.web.rest.errors.HigherNumberOfDtxsidException;
+import gov.epa.ccte.api.chemical.web.rest.errors.HigherNumberOfIdsException;
 import gov.epa.ccte.api.chemical.web.rest.errors.IdentifierNotFoundException;
+import gov.epa.ccte.api.chemical.web.rest.requests.Page;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -38,10 +39,22 @@ public class ChemicalDetailResource {
     @Value("${application.batch-size}")
     private Integer batchSize;
 
+    private Long totalChemicals;
+
     public ChemicalDetailResource(ChemicalDetailService detailService) {
         this.detailService = detailService;
+
+        totalChemicals = detailService.getTotalChemicals();
     }
 
+    @RequestMapping(value = "chemical/all", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    public @ResponseBody
+    Page getAllChemicalDetails(@RequestParam(value = "next", required = false, defaultValue = "1") Long next) {
+
+        log.debug("nextCursor: {}, totalChemicals = {}", next, totalChemicals);
+
+        return detailService.getAllChemicals(next, batchSize, totalChemicals);
+    }
     /**
      * {@code GET  /chemical/detail/by-dtxsid/:dtxsid} : get list of chemicalDetail for the "dtxsid".
      *
@@ -100,33 +113,33 @@ public class ChemicalDetailResource {
     }
 
     /**
-     * {@code POST  /chemical/detail/search/ : get list of chemicalDetail for the multiple "dtxsid".
-     * @param BatchRequest the matching dtxcid of the chemicalDetail to retrieve.
+     * {@code POST  chemical/detail/search/by-dtxsid/ : get list of chemicalDetail for the multiple "dtxsid".
+     * @param BatchRequest the matching dtxsid of the chemicalDetail to retrieve.
      * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the list of chemicalDetail}.
      */
     @Operation(summary = "Get data by the batch of dtxsids",
-            description = "Besides batch of the values, the user can also define projection (set of attributes to return). Note: Maximum 200 DTXSIDs per request")
+            description = "Besides batch of the values, the user can also define projection (set of attributes to return). Note: Maximum ${application.batch-size} DTXSIDs per request")
     @ApiResponses(value= {
             @ApiResponse(responseCode = "200", description = "OK",  content = @Content( mediaType = "application/json",
                     schema=@Schema(oneOf = {ChemicalDetailStandard.class, ChemicalIdentifier.class, ChemicalStructure.class}))),
             @ApiResponse(responseCode = "400", description = "When user has submitted more then allowed number (${application.batch-size}) of DTXSID(s).",
                     content = @Content( mediaType = "application/problem+json",
-                    examples = {@ExampleObject(value = "{\"title\":\"Validation Error\",\"status\":400,\"detail\":\"System supports only '200' dtxsid at one time, '202' are submitted.\"}", description = "Validation error for more then allowed number of dtxsid(s).")},
-                    schema=@Schema(oneOf = {ProblemDetail.class})))
+                            examples = {@ExampleObject(value = "{\"title\":\"Validation Error\",\"status\":400,\"detail\":\"System supports only '200' dtxsid at one time, '202' are submitted.\"}", description = "Validation error for more then allowed number of dtxsid(s).")},
+                            schema=@Schema(oneOf = {ProblemDetail.class})))
     })
     @RequestMapping(value = "chemical/detail/search/by-dtxsid/", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
     public @ResponseBody
-    List batchSearch( @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, description = "JSON array of DSSTox Substance Identifier",
+    List batchDtxsidSearch( @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, description = "JSON array of DSSTox Substance Identifier",
             content = {@Content (array = @ArraySchema(schema = @Schema(implementation = String.class)),
-                        examples = {@ExampleObject("\"[\\\"DTXSID7020182\\\",\\\"DTXSID9020112\\\"]\"")})})
-                      @RequestBody String[] dtxsids,
-                      @RequestParam(value = "projection", required = false, defaultValue = "chemicaldetailall")
-                      ChemicalDetailProjection projection) {
+                    examples = {@ExampleObject("\"[\\\"DTXSID7020182\\\",\\\"DTXSID9020112\\\"]\"")})})
+                            @RequestBody String[] dtxsids,
+                            @RequestParam(value = "projection", required = false, defaultValue = "chemicaldetailall")
+                            ChemicalDetailProjection projection) {
 
         log.debug("dtxsids = {}", dtxsids.length);
 
         if(dtxsids.length > batchSize)
-            throw new HigherNumberOfDtxsidException(dtxsids.length, batchSize);
+            throw new HigherNumberOfIdsException(dtxsids.length, batchSize, "dtxsid" );
 
         List data =  getChemicalDetails(dtxsids, "dtxsid", projection);
         log.debug("database return {}", data.size());
@@ -134,22 +147,58 @@ public class ChemicalDetailResource {
         return data;
     }
 
-    private List getChemicalDetails(String[] dtxsids, String type, ChemicalDetailProjection projection) {
+    /**
+     * {@code POST  chemical/detail/search/by-dtxcid/ : get list of chemicalDetail for the multiple "dtxcid".
+     * @param BatchRequest the matching dtxcid of the chemicalDetail to retrieve.
+     * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the list of chemicalDetail}.
+     */
+    @Operation(summary = "Get data by the batch of dtxcids",
+            description = "Besides batch of the values, the user can also define projection (set of attributes to return). Note: Maximum ${application.batch-size} DTXCIDs per request")
+    @ApiResponses(value= {
+            @ApiResponse(responseCode = "200", description = "OK",  content = @Content( mediaType = "application/json",
+                    schema=@Schema(oneOf = {ChemicalDetailStandard.class, ChemicalIdentifier.class, ChemicalStructure.class}))),
+            @ApiResponse(responseCode = "400", description = "When user has submitted more then allowed number (${application.batch-size}) of DTXCID(s).",
+                    content = @Content( mediaType = "application/problem+json",
+                            examples = {@ExampleObject(value = "{\"title\":\"Validation Error\",\"status\":400,\"detail\":\"System supports only '${application.batch-size}' dtxsid at one time, '${application.batch-size+1}' are submitted.\"}", description = "Validation error for more then allowed number of dtxsid(s).")},
+                            schema=@Schema(oneOf = {ProblemDetail.class})))
+    })
+    @RequestMapping(value = "chemical/detail/search/by-dtxcid/", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+    public @ResponseBody
+    List batchDtxcidSearch( @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, description = "JSON array of DSSTox Compound Identifier",
+            content = {@Content (array = @ArraySchema(schema = @Schema(implementation = String.class)),
+                    examples = {@ExampleObject("\"[\\\"DTXCID505\\\",\\\"DTXSID9020112\\\"]\"")})})
+                            @RequestBody String[] dtxcids,
+                            @RequestParam(value = "projection", required = false, defaultValue = "chemicaldetailall")
+                            ChemicalDetailProjection projection) {
+
+        log.debug("dtxcids = {}", dtxcids.length);
+
+        if(dtxcids.length > batchSize)
+            throw new HigherNumberOfIdsException(dtxcids.length, batchSize, "dtxcid" );
+
+        List data =  getChemicalDetails(dtxcids, "dtxcid", projection);
+        log.debug("database return {}", data.size());
+
+        return data;
+    }
+
+    private List getChemicalDetails(String[] ids, String type, ChemicalDetailProjection projection) {
         return switch (projection) {
             case chemicaldetailall ->
-                    detailService.getChemicalDetailsForBatch(dtxsids, ChemicalDetailAll.class, type);
+                    detailService.getChemicalDetailsForBatch(ids, ChemicalDetailAll.class, type);
             case chemicaldetailstandard ->
-                    detailService.getChemicalDetailsForBatch(dtxsids, ChemicalDetailStandard.class, type);
+                    detailService.getChemicalDetailsForBatch(ids, ChemicalDetailStandard.class, type);
             case chemicalidentifier ->
-                    detailService.getChemicalDetailsForBatch(dtxsids, ChemicalIdentifier.class, type);
+                    detailService.getChemicalDetailsForBatch(ids, ChemicalIdentifier.class, type);
             case chemicalstructure ->
-                    detailService.getChemicalDetailsForBatch(dtxsids, ChemicalStructure.class, type);
-            case ntatoolkit -> detailService.getChemicalDetailsForBatch(dtxsids, NtaToolkit.class, type);
-            case ccdchemicaldetails -> detailService.getChemicalDetailsForBatch(dtxsids, CcdChemicalDetails.class, type);
+                    detailService.getChemicalDetailsForBatch(ids, ChemicalStructure.class, type);
+            case ntatoolkit -> detailService.getChemicalDetailsForBatch(ids, NtaToolkit.class, type);
+            case ccdchemicaldetails -> detailService.getChemicalDetailsForBatch(ids, CcdChemicalDetails.class, type);
+            case compact -> detailService.getChemicalDetailsForBatch(ids, Compact.class, type);
         };
     }
 
-    /**
+    /*
      * {@code GET  /chemical/detail/search/by-listname/:listname} : get list of chemicalDetail for the "listname".
      *
      * @param listname chemicals defined in this list will return with chemical details.

--- a/src/main/java/gov/epa/ccte/api/chemical/web/rest/ChemicalListResource.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/web/rest/ChemicalListResource.java
@@ -143,9 +143,14 @@ public class ChemicalListResource {
 
         log.debug("dtxsid={}, projection={}", dtxsid, projection);
 
+        // Get chemical lists link to requested dtxsid
+        List<String> chemicalLists = chemicalListChemicalRepository.getListNames(dtxsid, "PUBLIC");
+
         return switch (projection){
-            case chemicallistname -> chemicalListChemicalRepository.getListNames(dtxsid, "PUBLIC");
+            case chemicallistname ->  listRepository.findByListNameInIgnoreCaseAndVisibilityAndIsVisibleOrderByListNameAsc(chemicalLists, "PUBLIC", true, ChemicalListName.class);
+            //case chemicallistall -> listRepository.findByListNameInIgnoreCaseAndVisibilityAndIsVisibleOrderByListNameAsc(chemicalLists, "PUBLIC", true, ChemicalListAll.class);
             case chemicallistall -> listRepository.getListsByDtxsid(dtxsid, "PUBLIC");
+            case ccdchemicaldetaillists -> listRepository.getListsByDtxsid(dtxsid, "PUBLIC");
            // case chemicalListwithdtxsids -> listRepository.getListsByDtxsidWithDtxsids(dtxsid, "PUBLIC");
             default -> null;
         };
@@ -153,6 +158,7 @@ public class ChemicalListResource {
     }
 
 
+    @Operation(summary = "Get dtxsids for starting value", description = "Returns an array of DTXSIDs for chemicals whose names start with the given characters, restricted to the specified chemical list.")
     @RequestMapping(value = "chemical/list/chemicals/search/start-with/{list}/{word}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public @ResponseBody
     List<String> startWith(@PathVariable String list, @PathVariable String word){
@@ -165,6 +171,7 @@ public class ChemicalListResource {
 
     }
 
+    @Operation(summary = "Get dtxsids for contain value", description = "Returns an array of DTXSIDs for chemicals whose names contain the given characters, restricted to the specified chemical list.")
     @RequestMapping(value = "chemical/list/chemicals/search/contain/{list}/{word}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public @ResponseBody
     List<String> contain(@PathVariable String list, @PathVariable String word){
@@ -177,6 +184,7 @@ public class ChemicalListResource {
 
     }
 
+    @Operation(summary = "Get dtxsids for exact value", description = "Returns an array of DTXSIDs for chemicals whose names matches exactly with the given characters, restricted to the specified chemical list.")
     @RequestMapping(value = "chemical/list/chemicals/search/equal/{list}/{word}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public @ResponseBody
     List<String> exact(@PathVariable String list, @PathVariable String word){
@@ -189,6 +197,17 @@ public class ChemicalListResource {
 
     }
 
+    @Operation(summary = "Get dtxsids for list name", description = "Returns an array of DTXSIDs for chemicals whose names matches exactly with the given characters, restricted to the specified chemical list.")
+    @RequestMapping(value = "chemical/list/chemicals/search/by-listname/{list}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    public @ResponseBody
+    List<String> listDtxsids(@PathVariable String list){
+
+        log.debug("list={}", list);
+
+        return chemicalListChemicalRepository.getDtxsids(list);
+
+    }
+
     @Operation(hidden = true)
     @RequestMapping(value = "chemical/list/chemicals/search/by-dtxsid", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
     public @ResponseBody
@@ -197,6 +216,8 @@ public class ChemicalListResource {
         log.debug("dtxsids = {}, chemical lists = {}", request.getDtxsids().size(), request.getChemicalLists().size());
 
         List<String> result = chemicalListChemicalRepository.chemicalListsAndDtxsids(request.getChemicalLists(), request.getDtxsids());
+
+        log.info("result.size={}", result.size());
 
         return result;
 

--- a/src/main/java/gov/epa/ccte/api/chemical/web/rest/ChemicalPropertyResource.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/web/rest/ChemicalPropertyResource.java
@@ -6,7 +6,7 @@ import gov.epa.ccte.api.chemical.dto.mapper.ChemicalPropertyMapper;
 import gov.epa.ccte.api.chemical.projection.ChemicalPropertyAll;
 import gov.epa.ccte.api.chemical.projection.ChemicalPropertyIds;
 import gov.epa.ccte.api.chemical.repository.ChemicalPropertyRepository;
-import gov.epa.ccte.api.chemical.web.rest.errors.HigherNumberOfDtxsidException;
+import gov.epa.ccte.api.chemical.web.rest.errors.HigherNumberOfIdsException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -123,7 +123,7 @@ public class ChemicalPropertyResource {
                     schema=@Schema(oneOf = {ChemicalPropertyAll.class}))),
             @ApiResponse(responseCode = "400", description = "When user has submitted more then allowed number (${application.batch-size}) of DTXSID(s).",
                     content = @Content( mediaType = "application/json",
-                    examples = {@ExampleObject(name = "", value = "{\"title\":\"Validation Error\",\"status\":400,\"detail\":\"System supports only '200' dtxsid at one time, '202' are submitted.\"}", description = "Validation error for more then allowed number of dtxsid(s).")},
+                    examples = {@ExampleObject(value = "{\"title\":\"Validation Error\",\"status\":400,\"detail\":\"System supports only '200' dtxsid at one time, '202' are submitted.\"}", description = "Validation error for more then allowed number of dtxsid(s).")},
                     schema=@Schema(oneOf = {ProblemDetail.class})))
     })
     @RequestMapping(value = "chemical/property/search/by-dtxsid/", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
@@ -136,7 +136,7 @@ public class ChemicalPropertyResource {
         log.debug("dtxsids = {}", dtxsids.length);
 
         if(dtxsids.length > batchSize)
-            throw new HigherNumberOfDtxsidException(dtxsids.length, batchSize);
+            throw new HigherNumberOfIdsException(dtxsids.length, batchSize, "dtxsid" );
 
         return repository.findByDtxsidInOrderByDtxsidAscPropTypeAscNameAsc(dtxsids, ChemicalPropertyAll.class);
     }

--- a/src/main/java/gov/epa/ccte/api/chemical/web/rest/ChemicalResource.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/web/rest/ChemicalResource.java
@@ -3,6 +3,8 @@ package gov.epa.ccte.api.chemical.web.rest;
 
 import io.swagger.v3.oas.annotations.Hidden;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,8 +17,30 @@ import org.springframework.web.bind.annotation.RestController;
 @CrossOrigin
 @Hidden // OpenAPI annotation for hidding endpoints from documentation generator
 public class ChemicalResource {
-    @GetMapping("test")
-    public String greeting(){
-        return "Hello world";
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public ChemicalResource(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @GetMapping("/chemical/health")
+    public ResponseEntity health(){
+
+        log.info("checking the health");
+
+        if(jdbcTemplate != null){
+            try {
+                jdbcTemplate.execute("SELECT 1 ");
+                log.debug("DB connection established");
+
+                return ResponseEntity.ok().build();
+
+            } catch (Exception ep){
+                return ResponseEntity.notFound().build();
+            }
+        }else {
+            return ResponseEntity.notFound().build();
+        }
     }
 }

--- a/src/main/java/gov/epa/ccte/api/chemical/web/rest/ChemicalSynonymResource.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/web/rest/ChemicalSynonymResource.java
@@ -5,20 +5,25 @@ import gov.epa.ccte.api.chemical.dto.ChemicalSynonymDto;
 import gov.epa.ccte.api.chemical.dto.mapper.ChemicalSynonymMapper;
 import gov.epa.ccte.api.chemical.projection.ChemicalSynonymAll;
 import gov.epa.ccte.api.chemical.repository.ChemicalSynonymRepository;
+import gov.epa.ccte.api.chemical.web.rest.errors.HigherNumberOfIdsException;
 import gov.epa.ccte.api.chemical.web.rest.errors.IdentifierNotFoundException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -31,6 +36,9 @@ import java.util.List;
 @RestController
 public class ChemicalSynonymResource {
 
+    @Value("${application.batch-size}")
+    private Integer batchSize;
+
     final private ChemicalSynonymRepository repository;
     final private ChemicalSynonymMapper mapper;
 
@@ -41,7 +49,6 @@ public class ChemicalSynonymResource {
 
     /**
      * {@code GET  /chemical/Synonym/search/by-dtxsid/{dtxsid} : get ChemicalSynonymDto for the "dtxsid".
-     *
      * @param dtxsid the matching dtxsid of the Chemical Property data to retrieve.
      * @return the {@link ResponseEntity } with status {@code 200 (OK)} and with body the list of Chemical Property data}.
      */
@@ -56,13 +63,42 @@ public class ChemicalSynonymResource {
 
         log.info("dtxsid = {}", dtxsid);
 
-        List<ChemicalSynonymDto> synonymDtos;
+       /*  List<ChemicalSynonymDto> synonymDtos;
+        ChemicalSynonym synonym = repository.findByDtxsid(dtxsid, ChemicalSynonymAll.class).orElseThrow(()->new IdentifierNotFoundProblem("DTXSID", dtxsid));
+         return mapper.toDto(synonym);*/
 
-        //ChemicalSynonym synonym = repository.findByDtxsid(dtxsid, ChemicalSynonymAll.class).orElseThrow(()->new IdentifierNotFoundProblem("DTXSID", dtxsid));
-
-        // return mapper.toDto(synonym);
-
-        return repository.findByDtxsid(dtxsid, ChemicalSynonymAll.class).orElseThrow(()->new IdentifierNotFoundException("DTXSID", dtxsid));
+        return repository.findByDtxsidAndIsPublic(dtxsid, true, ChemicalSynonymAll.class).orElseThrow(()->new IdentifierNotFoundException("DTXSID", dtxsid));
     }
+
+    /**
+     * {@code POST  /chemical/Synonym/search/by-dtxsid/ : get List of ChemicalSynonymDto for the batch of "dtxsid".
+     * @param dtxsid the matching dtxsid of the Chemical Property data to retrieve.
+     * @return the {@link ResponseEntity } with status {@code 200 (OK)} and with body the list of Chemical Property data}.
+     */
+    @Operation(summary = "Get synonyms by the batch of dtxsida")
+    @RequestMapping(value = "chemical/synonym/search/by-dtxsid/", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value= {
+            @ApiResponse(responseCode = "200", description = "OK",  content = @Content( mediaType = "application/json",
+                    schema=@Schema(oneOf = {ChemicalSynonymAll.class})))
+    })
+    public @ResponseBody
+    List synoymsByBatchDtxsid(@io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, description = "JSON array of DSSTox Substance Identifier",
+            content = {@Content (array = @ArraySchema(schema = @Schema(implementation = String.class)),
+                    examples = {@ExampleObject("\"[\\\"DTXSID7020182\\\",\\\"DTXSID9020112\\\"]\"")})})
+                                            @RequestBody String[] dtxsids) {
+
+        log.info("dtxsid size = {}", dtxsids.length);
+
+        if(dtxsids.length > batchSize)
+            throw new HigherNumberOfIdsException(dtxsids.length, batchSize, "dtxsid" );
+
+       /*  List<ChemicalSynonymDto> synonymDtos;
+        ChemicalSynonym synonym = repository.findByDtxsid(dtxsid, ChemicalSynonymAll.class).orElseThrow(()->new IdentifierNotFoundProblem("DTXSID", dtxsid));
+         return mapper.toDto(synonym);*/
+        List result = repository.findByDtxsidInAndIsPublicOrderByDtxsidAsc(Arrays.asList(dtxsids), true, ChemicalSynonymAll.class);;
+
+        return result;
+    }
+
 
 }

--- a/src/main/java/gov/epa/ccte/api/chemical/web/rest/ExtraDataResource.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/web/rest/ExtraDataResource.java
@@ -1,0 +1,98 @@
+package gov.epa.ccte.api.chemical.web.rest;
+
+import gov.epa.ccte.api.chemical.domain.ExtraData;
+import gov.epa.ccte.api.chemical.repository.ExtraDataRepository;
+import gov.epa.ccte.api.chemical.web.rest.errors.HigherNumberOfIdsException;
+import gov.epa.ccte.api.chemical.web.rest.errors.IdentifierNotFoundException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * REST controller for getting the {@link ExtraData}s.
+ */
+@Tag(name = "Extra Data Resource",
+        description = "API endpoints for returning extra data relating to chemical(s) identified by DTXSID(s)")
+@SecurityRequirement(name = "api_key")
+@RequestMapping( value = "chemical/extra-data", produces = MediaType.APPLICATION_JSON_VALUE)
+
+@Slf4j
+@RestController
+public class ExtraDataResource {
+    final private ExtraDataRepository repository;
+
+    @Value("2000")
+    private Integer batchSize;
+
+    public ExtraDataResource(ExtraDataRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * {@code GET  /chemical/extra-data/by-dtxsid/:dtxsid} : get list of extra chemical for the "dtxsid".
+     *
+     * @param dtxsid the matching dtxsid of the extraData to retrieve.
+     * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the list of ExtraData.
+     */
+    @Operation(summary = "Get data by dtxsid",
+            description = "Specify the dtxsid as part of the path.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json",
+                    schema = @Schema(oneOf = {ExtraData.class}))),
+            @ApiResponse(responseCode = "400", description = "Data not found.",
+                    content = @Content(mediaType = "application/problem+json",
+                            examples = {@ExampleObject(value = "{\"title\":\"Bad Request\",\"status\":400,\"detail\":\"dtxsid with value (${application.dtxsid}) not found.\",\"instance\":[\"/chemical/extra-data/search/by-dtxsid/($application.dtxsid})\"]}", description = "Here response is with suggestion for 'caffiene'")},
+                            schema = @Schema(oneOf = {ExtraData.class})))
+    })
+    @RequestMapping(value = "/search/by-dtxsid/{dtxsid}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    public @ResponseBody
+    List<ExtraData> extraDataByDtxsid(@Parameter(required = true, description = "DSSTox Substance Identifier", example = "DTXSID101296374") @PathVariable("dtxsid") String dtxsid) {
+        log.debug("dtxsid = {}", dtxsid);
+
+        List<ExtraData> data = repository.findByDtxsid(dtxsid, ExtraData.class);
+        if (data.isEmpty())
+            throw new IdentifierNotFoundException("dtxsid", dtxsid);
+        else
+            return data;
+    }
+
+    /**
+     * {@code POST  /chemical/extra-data/by-dtxsid/} : get list of extra chemical for batch of "dtxsids".
+     *
+     * @param dtxsids the matching dtxsids of the extraData to retrieve.
+     * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the list of ExtraData.
+     */
+    @Operation(summary = "Get data by dtxsid",
+            description = "Specify the dtxsid as part of the path.")
+    @ApiResponses(value= {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json",
+                    schema = @Schema(oneOf = {ExtraData.class})))
+    })
+    @RequestMapping(value = "/search/by-dtxsid/", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+    public @ResponseBody
+    List<ExtraData> batchSearchExtraData(@io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, description = "JSON array of DSSTox Substance Identifier",
+        content = {@Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
+             examples = {@ExampleObject("\"[\\\"DTXSID101296374\\\",\\\"DTXSID10612113\\\",\\\"DTXSID20635878\\\"]\"")})})
+                                        @RequestBody String[] dtxsids){
+        if(dtxsids.length > batchSize)
+            throw new HigherNumberOfIdsException(dtxsids.length, batchSize, "dtxsids");
+
+        List<ExtraData> data = repository.findByDtxsidInOrderByDtxsidAsc(dtxsids, ExtraData.class);
+
+        return data;
+    }
+}

--- a/src/main/java/gov/epa/ccte/api/chemical/web/rest/FateResource.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/web/rest/FateResource.java
@@ -4,7 +4,7 @@ import gov.epa.ccte.api.chemical.domain.Fate;
 import gov.epa.ccte.api.chemical.dto.mapper.FateMapper;
 import gov.epa.ccte.api.chemical.projection.FateAll;
 import gov.epa.ccte.api.chemical.repository.FateRepository;
-import gov.epa.ccte.api.chemical.web.rest.errors.HigherNumberOfDtxsidException;
+import gov.epa.ccte.api.chemical.web.rest.errors.HigherNumberOfIdsException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -71,7 +71,7 @@ public class FateResource {
                     schema=@Schema(oneOf = {FateAll.class}))),
             @ApiResponse(responseCode = "400", description = "When user has submitted more then allowed number (${application.batch-size}) of DTXSID(s).",
                     content = @Content( mediaType = "application/problem+json",
-                    examples = {@ExampleObject(name = "", value = "{\"title\":\"Validation Error\",\"status\":400,\"detail\":\"System supports only '200' dtxsid at one time, '202' are submitted.\"}", description = "Validation error for more then allowed number of dtxsid(s).")},
+                    examples = {@ExampleObject(value = "{\"title\":\"Validation Error\",\"status\":400,\"detail\":\"System supports only '200' dtxsid at one time, '202' are submitted.\"}", description = "Validation error for more then allowed number of dtxsid(s).")},
                     schema=@Schema(oneOf = {ProblemDetail.class})))
     })
     @RequestMapping(value = "chemical/fate/search/by-dtxsid/", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
@@ -84,7 +84,7 @@ public class FateResource {
         log.debug("dtxsids = {}", dtxsids.length);
 
         if(dtxsids.length > batchSize)
-            throw new HigherNumberOfDtxsidException(dtxsids.length, batchSize);
+            throw new HigherNumberOfIdsException(dtxsids.length, batchSize, "dtxsid" );
 
         return repository.findByDtxsidInOrderByDtxsidAscEndpointNameAsc(dtxsids, FateAll.class);
     }

--- a/src/main/java/gov/epa/ccte/api/chemical/web/rest/GhsLinkResource.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/web/rest/GhsLinkResource.java
@@ -1,0 +1,61 @@
+package gov.epa.ccte.api.chemical.web.rest;
+
+import gov.epa.ccte.api.chemical.repository.ChemicalListChemicalRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * REST controller for checking availability of data in Pubchem for GHS Safety data
+ */
+@Tag(name = "Pubchem link to GHS Classification ",
+        description = "API endpoints for checking if chemical has GHS classification safety data in Pubchem. ")
+@SecurityRequirement(name = "api_key") // no need for api_key for this endpoint
+@Slf4j
+@RestController
+public class GhsLinkResource {
+
+    final private ChemicalListChemicalRepository chemicalListChemicalRepository;
+
+    public GhsLinkResource(ChemicalListChemicalRepository chemicalListChemicalRepository) {
+
+        this.chemicalListChemicalRepository = chemicalListChemicalRepository;
+    }
+
+    @Operation(summary = "Check existence by dtxsid", description = "This endpoint will return Y if Pubchem has GHS Safety data otherwise it will return N.")
+    @RequestMapping(value = "chemical/ghslink/to-dtxsid/{dtxsid}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    public @ResponseBody
+    GhsLinkResponse byDtxsid(@Parameter(required = true, description = "DSSTox Substance Identifier", example = "DTXSID7020182") @PathVariable("dtxsid") String dtxsid) {
+
+        log.debug("Received request to check existence by dtxsid: {} ", dtxsid);
+
+        if(chemicalListChemicalRepository.isGhsLinkExists(new String[]{dtxsid}).isEmpty())
+            return new GhsLinkResponse(dtxsid, false, null);
+        else
+            return chemicalListChemicalRepository.isGhsLinkExists(new String[]{dtxsid}).get(0);
+    }
+
+    @Operation(summary = "Check existence for batch of dtxsid", description = "This endpoint will return Y if Pubchem has GHS Safety data otherwise it will return N.")
+    @RequestMapping(value = "chemical/ghslink/to-dtxsid/", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+    public @ResponseBody
+    List<GhsLinkResponse> byBatchDtxsid(@io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, description = "JSON array of DSSTox Substance Identifier",
+            content = {@Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
+                    examples = {@ExampleObject("\"[\\\"DTXSID7020182\\\",\\\"DTXSID9020112\\\"]\"")})})
+                                  @RequestBody String[] dtxsids) {
+
+        log.debug("Received request to check existence by {} dtxsid: ", dtxsids.length);
+
+        return chemicalListChemicalRepository.isGhsLinkExists(dtxsids);
+    }
+
+}

--- a/src/main/java/gov/epa/ccte/api/chemical/web/rest/GhsLinkResponse.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/web/rest/GhsLinkResponse.java
@@ -1,0 +1,14 @@
+package gov.epa.ccte.api.chemical.web.rest;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+public class GhsLinkResponse {
+    String dtxsid;
+    Boolean isSafetyData;
+    String safetyUrl;
+}

--- a/src/main/java/gov/epa/ccte/api/chemical/web/rest/IndigoResource.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/web/rest/IndigoResource.java
@@ -35,6 +35,17 @@ public class IndigoResource {
         log.debug("mol file size = {}", mol.length());
 
 
+        return indigoService.mol2inchi(mol);
+    }
+
+    @Operation(summary = "Get InChIkey from mol")
+    @RequestMapping(value = "chemical/indigo/to-inchikey", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+    public @ResponseBody
+    String toInChIkey(@Parameter(required = true, description = "mol file") @RequestBody() String mol) throws IOException {
+
+        log.debug("mol file size = {}", mol.length());
+
+
         return indigoService.mol2inchikey(mol);
     }
 

--- a/src/main/java/gov/epa/ccte/api/chemical/web/rest/WikipediaLinkResource.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/web/rest/WikipediaLinkResource.java
@@ -1,0 +1,62 @@
+package gov.epa.ccte.api.chemical.web.rest;
+
+import gov.epa.ccte.api.chemical.repository.ChemicalListChemicalRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * REST controller for checking availability of data in Pubchem for GHS Safety data
+ */
+@Tag(name = "Pubchem link to GHS Classification ",
+        description = "API endpoints for checking if chemical has GHS classification safety data in Pubchem. ")
+@SecurityRequirement(name = "api_key") // no need for api_key for this endpoint
+@Slf4j
+@RestController
+public class WikipediaLinkResource {
+
+    final private ChemicalListChemicalRepository chemicalListChemicalRepository;
+
+    public WikipediaLinkResource(ChemicalListChemicalRepository chemicalListChemicalRepository) {
+
+        this.chemicalListChemicalRepository = chemicalListChemicalRepository;
+    }
+
+    @Operation(summary = "Check existence by dtxsid", description = "This endpoint will return Y if Wikipedia has GHS Safety data otherwise it will return N.")
+    @RequestMapping(value = "chemical/wikipedia/by-dtxsid/{dtxsid}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    public @ResponseBody
+    WikipediaLinkResponse byDtxsid(@Parameter(required = true, description = "DSSTox Substance Identifier", example = "DTXSID7020182") @PathVariable("dtxsid") String dtxsid) {
+
+        log.debug("Received request to check existence by dtxsid: {} ", dtxsid);
+
+        if(chemicalListChemicalRepository.isWikipediaLinkExists(new String[]{dtxsid}).isEmpty())
+            return new WikipediaLinkResponse(dtxsid, null);
+        else
+            return chemicalListChemicalRepository.isWikipediaLinkExists(new String[]{dtxsid}).get(0);
+    }
+
+    @Operation(summary = "Check existence for batch of dtxsid", description = "This endpoint will return Y if Wikipedia has GHS Safety data otherwise it will return N.")
+    @RequestMapping(value = "chemical/wikipedia/by-dtxsid/", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+    public @ResponseBody
+    List<WikipediaLinkResponse> byBatchDtxsid(@io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, description = "JSON array of DSSTox Substance Identifier",
+            content = {@Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
+                    examples = {@ExampleObject("\"[\\\"DTXSID7020182\\\",\\\"DTXSID9020112\\\"]\"")})})
+                                        @RequestBody String[] dtxsids) {
+
+        log.debug("Received request to check existence by {} dtxsid: ", dtxsids.length);
+
+        return chemicalListChemicalRepository.isWikipediaLinkExists(dtxsids);
+    }
+
+}
+

--- a/src/main/java/gov/epa/ccte/api/chemical/web/rest/WikipediaLinkResponse.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/web/rest/WikipediaLinkResponse.java
@@ -1,0 +1,13 @@
+package gov.epa.ccte.api.chemical.web.rest;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+public class WikipediaLinkResponse {
+    String dtxsid;
+    String safetyUrl;
+}

--- a/src/main/java/gov/epa/ccte/api/chemical/web/rest/errors/APIExceptionHandler.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/web/rest/errors/APIExceptionHandler.java
@@ -1,6 +1,7 @@
 package gov.epa.ccte.api.chemical.web.rest.errors;
 
 import org.springframework.http.*;
+import org.springframework.lang.NonNull;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -14,8 +15,8 @@ import java.util.Map;
 @RestControllerAdvice
 public class APIExceptionHandler extends ResponseEntityExceptionHandler {
 
-    @ExceptionHandler(HigherNumberOfDtxsidException.class)
-    ProblemDetail handleHigherNumberOfDtxsidException(HigherNumberOfDtxsidException ex){
+    @ExceptionHandler(HigherNumberOfIdsException.class)
+    ProblemDetail handleHigherNumberOfDtxsidException(HigherNumberOfIdsException ex){
         return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
     }
 
@@ -49,7 +50,7 @@ public class APIExceptionHandler extends ResponseEntityExceptionHandler {
 //    }
 
     @Override
-    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(@NonNull MethodArgumentNotValidException ex, @NonNull HttpHeaders headers, @NonNull HttpStatusCode status, @NonNull WebRequest request) {
 
         ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
         problemDetail.setTitle("Constraint Violations");

--- a/src/main/java/gov/epa/ccte/api/chemical/web/rest/errors/HigherNumberOfIdsException.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/web/rest/errors/HigherNumberOfIdsException.java
@@ -1,0 +1,9 @@
+package gov.epa.ccte.api.chemical.web.rest.errors;
+
+
+public class HigherNumberOfIdsException extends RuntimeException {
+
+    public HigherNumberOfIdsException(Integer size, Integer maxSize, String idType) {
+        super(String.format("System supports only '%s' '%s' at one time, '%s' are submitted.",maxSize, size, idType));
+    }
+}

--- a/src/main/java/gov/epa/ccte/api/chemical/web/rest/requests/Page.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/web/rest/requests/Page.java
@@ -1,0 +1,16 @@
+package gov.epa.ccte.api.chemical.web.rest.requests;
+
+import gov.epa.ccte.api.chemical.projection.chemicaldetail.ChemicalDetailStandard2;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class Page {
+    private Integer size=2000;
+    private Long total;
+    private Long next;
+    private List<ChemicalDetailStandard2> data;
+}

--- a/src/main/resources/synonym.cfx
+++ b/src/main/resources/synonym.cfx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84267199f9d5c87d744da61531fbb25b3523b63dfe79af9ebe37e7a3db158ad0
+size 323205320

--- a/src/test/java/gov/epa/ccte/api/chemical/datatest/ChemicalSearchRepositoryTest.java
+++ b/src/test/java/gov/epa/ccte/api/chemical/datatest/ChemicalSearchRepositoryTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Limit;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -47,7 +48,7 @@ public class ChemicalSearchRepositoryTest {
 
     @Test
     void testFindByModifiedValueStartingWithAndSearchNameInOrderByRankAscSearchValue(){
-        assertThat(repository.findByModifiedValueStartingWithAndSearchNameInOrderByRankAscSearchValue("BPA", searchMatchWithoutInchikey, ChemicalSearchAll.class).size()).isEqualTo(1);
+        assertThat(repository.findByModifiedValueStartingWithAndSearchNameInOrderByRankAscSearchValue("BPA", searchMatchWithoutInchikey, Limit.unlimited(), ChemicalSearchAll.class).size()).isEqualTo(1);
     }
 
     @Test
@@ -57,6 +58,6 @@ public class ChemicalSearchRepositoryTest {
 
     @Test
     void testFindByModifiedValueContainsOrderByRankAscDtxsidAsc(){
-        assertThat(repository.findByModifiedValueContainsOrderByRankAscDtxsid("BPA", ChemicalSearchAll.class).size()).isEqualTo(1);
+        assertThat(repository.findByModifiedValueContainsOrderByRankAscDtxsid("BPA", Limit.unlimited(), ChemicalSearchAll.class).size()).isEqualTo(1);
     }
 }


### PR DESCRIPTION
* updated apikey code and manifest files.

* API doc, batch search and projection implementation.

* Chemical Property id is implemented.

* Add staging environment to OpenAPI

* Added projections and update OpenAPI doc.

* Update OpenAPI documentation

* Update OpenAPI documentation

* Bug fix with chemical detail projection.

* Add spring profile base server location for openapi

* fixed the cors issue with api-key

* fixed the cors issue with api-key

* implemented batch size restriction

* Reinitializing the code

* local build/deploy scripts

* Updated no data error message and casrn with wrong dash.

* refine search logic

* CaffeineFix implementation and NtaToolkit

* Make the list name endpoints Case-Insensitive

Now user can provide list name in any case. There two endpoints which are impacted by this change. /chemical/list/search/by-name
/chemical/list/chemicals/search/by-listname/

* Adding API deprecating message to open api specification.

* Update the code to move to jdk17.

* Fix the caffeineFix synonym search with new cfx file.

* Added test cases for data repository #2

* Added test cases for data repository #2

* Added test cases for data repository #2

* Added test cases for each controller using WebTestClient

* Remove the unit tests from deployment.

* Added start-with2 temporary endpoint for CCD.

* Added projection for chemical search

* 9 add inchikey search option when no direct match found (#12)

* Creating a Util class for chemical relate validation functions

* Creating test for chemical Util

* Implemented suggestions for inchikey #9

* Implemented suggestions for inchikey #9

* Implemented suggestions for inchikey #9

* 11 start with chemical search option needs to update for full chemical name search (#13)

* implemented the changes for CE-3553 related to #11

* implemented the changes for CE-3553 related to #11

* implemented the changes for CE-3742 related to #11

* 1 upgrade ccte api chemical code to spring 6 (#15)

* upgrade spring boot 3 #1

* upgrade spring boot 3 #1

* Added batch chemical search for \equal endpoint. (#14)

* remove deprecated flag from chemical file and fix other issues.

* upgrade to spring boot 3.2.0

* Reduce the memory requirement for stg to 1GB.

* App didn't work with 1GB, I have to increase to 2GB.

* Upgrade the java-cfenv to latest version

* Added batch search for ms-ready mass search #18 (#19)

* Update exception code since ResponseEntityExceptionHandler already implement MethodArgumentNotValidException #18

* Update exception code since ResponseEntityExceptionHandler already implement MethodArgumentNotValidException #18

* Update exception code since ResponseEntityExceptionHandler already implement MethodArgumentNotValidException #18

* Implemented OPSIN resource and suggestions #17 (#21)

* Exact search is implemented for DTXSID and DTXCID #20 (#22)

* correct the string from inchi to InChI.

* APIKeystore is moved into a bean #20

* approvedOriginStore is moved into a bean #20

* Remove unnecessary columns from apikey domain and added data_scope #20

* updated api security into beans #20 (#25)

* 26 update chemical list api to new schema and table (#27)

* updated the chemical list apis #26

* updated the chemical list apis #26

* updated the chemical list apis #26

* updated the chemical list apis #26

* implmented structure image generat endpoint #28 (#29)

* 31 move chemical details table to ch schema from ms (#34)

* remove is_markus column, it is missing from chemical detail table #31

* updated the chemical detail entity with new table  #31

* 31 move chemical details table to ch schema from ms (#35)

* remove is_markus column, it is missing from chemical detail table #31

* updated the chemical detail entity with new table  #31

* updated the chemical detail entity with new table  #31

* 30 create a new endpoint for getting chemicals details for specific chemical list (#36)

* fix issues with projection chemicalListwithdtxsids #30

* implemented new endpoint for list details #30

* implemented new endpoint for list details #30

* 30 create a new endpoint for getting chemicals details for specific chemical list (#37)

* fix issues with projection chemicalListwithdtxsids #30

* implemented new endpoint for list details #30

* implemented new endpoint for list details #30

* Remove chemical list detail code #30

* updated the schema and table name for msready #32 (#39)

* 32 update the msready endpoint code for new table chmsready search (#40)

* updated the schema and table name for msready #32

* updated the schema and table name for msready #32

* 41 implement paging in chemicalsearchstart with and chemicalsearchcontain endpoints (#42)

* added top parameter to reduce number of return records #41

* added top parameter to reduce number of return records #41

* implemented endpoints for chemical search in lists #33 (#43)

* allow mixed case chemcial list name #33

* 44 update the start with option for chemical list to return search data (#45)

* fix the cors issue problem with localhost and https

* increase the batch size to 1000.

* 46 generate inchikey by a mol file (#47)

* created indigo resource for indigo toolkit #46

* created indigo resource for indigo toolkit #46

* added endpoint for ccd batch search #48 (#49)

* 48 endpoint for ccd batchsearch (#50)

* added endpoint for ccd batch search #48

* added endpoints for chemical list #48

* Dev-756 created Zap Scan for the APIs (#52)

* Create security-scan.yml

* Update security-scan.yml

* Update security-scan.yml

* Update security-scan.yml

* Update security-scan.yml

* Update security-scan.yml

* Update security-scan.yml

* Update security-scan.yml

* added external staging environment to approved hosts

* fix issue with projections and null valaues were returning.

* added projection to equal #57 (#59)

* Using the same code for chemical details for single and batch.

* Added debug msg for database return count

* added cache control to all requests, #60 (#61)

* Added a custom header on Zap scan (#54)

* Update security-scan.yml

* Update security-scan.yml

* Adjusting header

---------



* added support for CASRN without dashes #53 (#62)

* fixed private chemicals in chemical list to show up

* fixed CASRN dashes issue and bug related to inchikey and start-with #55 (#63)

* fixed CASRN dashes issue and bug related to inchikey and start-with #55

* fixed CASRN dashes issue and bug related to inchikey and start-with #55

* Data type is changed for is_markush flag.

* Data type is changed for is_markush flag.

* Added a projection for CCD.

* CAS-RN is changed to CASRN in search data.

* chemical search table is move to ch schema and changed the name.

* is_markush is changed to Boolean. projections were not changed. causing 500 error message.

* implemented projection for conaton query. #58 (#64)

* fix CORS issue with locahost requests

* remove chemicallist option from chemical details search options.

* added equal search option for chemical list.

* fix the text for operations. #65 (#66)

* added endpoint for inchikey #66

* added new projection (compact) for chemical details #70 (#71)

* update chemical_synonym apis to new table v_chemical_synonyms in ch schema.

* update chemical_synonym apis to new table v_chemical_synonyms in ch schema.

* implementation for date attribute.

* fix the chemical list search by dtxsid endpoints.

* revert the changes for chemical list search by dtxsid due to CCD.

* Add https://ccte-ccd.epa.gov for CORS

* implemented health endpoint #72

* added projection for ccd for in presence chemical list

* added projection for ccd for in presence chemical list

* added average_mass into CcdChemicalDetails projection

* fixed slow response with top parameter.

* clean up code.

* updated for contain search.

* 73 batch retrieve by dtxcid (#74)

* implemented batch search for dtxcid for details. #73

* remove it since we are using same method for batch and single search. #73

* fixed Javadoc issue #73

* remove the unuse code, now we have different way to getting chemcail details for lists #73

* fix an intelliJ code inspection warning #73

* clean up some code for intellij inspection warnings #73

* clean up some code for intellij inspection warnings #73

* implement batch search for synonyms #75 (#76)

* Add new devops vm for cors check.

* Updated API endpoints descriptions. #82 (#83)

* Added endpoint for safety data #84 (#85)

* Added batch endpoint for safety data #86 (#87)

* Create maven-publish.yml (#88)

Workflow to publish jar files

* Update maven-publish.yml

* Update maven-publish.yml

* add new endpoint #89 (#90)

* update the security for http://v2626umcth875.rtord.epa.gov:8001.

* Fix the url for GHS link.

* Added endpoint for gsid. #91 (#92)

* 93 dynamic loading of approved hostnames from database (#94)

* Add domain class for hostname in database. #93

* Add repository for ApprovedHost. #93

* Update config to load hosts from DB. #93

* Added the limit for start-with, #96 (#97)

* Hidde the chemical/test/{word} endpoint.

* Implemented new endpoint for getting all chemicals. #98 (#99)

* [DEV-886]  Deploy ccte-api-chemical Jar to Packages (#101)

* Update pom.xml

* Create gh-packages-deployment.yml

* Update gh-packages-deployment.yml

* [ DEV-876 ] Deploy ccte-api-chemical to Cloud.gov Staging (#105)

* Create deploy-staging.yml

* Update deploy-staging.yml

* 106 implement get method for chemicalextra datasearchby dtxsid endpoint in chemical microservice (#108)

* implement both GET and POST methods for new extra-data endpoint #106, #107

* implement both GET and POST methods for new extra-data endpoint #106, #107

* 109 api for wikipedia link for given dtxsid (#110)

* implement both GET and POST methods for new Wikipedia search endpoint #109

* implement both GET and POST methods for new Wikipedia search endpoint #109

* Add deploy prod automation and add new number of instances config (2) (#111)

* Add 2 instances instead of 1

* Create deploy-prod.yml

* CE-4383-Added changes to remove preceeding zeros for casrn number with or without dashes (#113)

* Adding synonym.cfx

* Add git lfs pull to deploy-staging.yml

* Add git lfs to deploy-prod.yml

* Duplicate method chemicalBatchEqual.

* Moving synonym.cfx file

* Duplicate method chemicalBatchEqual.

* fix the bug with contain endpoint. #120 (#121)

---------