### PR TITLE
CE-4965 Create additional summary endpoints for chemical properties and env. fates #266

### DIFF
--- a/src/main/java/gov/epa/ccte/api/chemical/projection/chemicalproperty/ChemicalPropertySummaryExperimental.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/projection/chemicalproperty/ChemicalPropertySummaryExperimental.java
@@ -1,0 +1,15 @@
+package gov.epa.ccte.api.chemical.projection.chemicalproperty;
+
+public interface ChemicalPropertySummaryExperimental {
+
+	String getSourceName();
+	String getSourceDescription();
+	String getPublicSourceUrl();
+	Double getPropValue();
+	String getDirectUrl();
+	String getAvailability();
+	Boolean getShowLink();
+	String getSpeciesLatin();
+	String getResponseSite();
+	
+}

--- a/src/main/java/gov/epa/ccte/api/chemical/projection/chemicalproperty/ChemicalPropertySummaryPredicted.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/projection/chemicalproperty/ChemicalPropertySummaryPredicted.java
@@ -1,0 +1,15 @@
+package gov.epa.ccte.api.chemical.projection.chemicalproperty;
+
+public interface ChemicalPropertySummaryPredicted {
+	
+	String getSourceName();
+	String getSourceDescription();
+	Double getPropValue();
+	String getLink();
+	String getLinkAvailability();
+	Boolean getShowLink();
+	String getQmrfUrl();
+	String getQmrfAvailability();
+	Boolean getShowQmrf();
+
+}

--- a/src/main/java/gov/epa/ccte/api/chemical/repository/ChemicalPropertyPredictedRepository.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/repository/ChemicalPropertyPredictedRepository.java
@@ -1,8 +1,7 @@
 package gov.epa.ccte.api.chemical.repository;
 
 import gov.epa.ccte.api.chemical.domain.ChemicalPropertyPredicted;
-import gov.epa.ccte.api.chemical.projection.chemicalproperty.ChemicalPropertyNames;
-import gov.epa.ccte.api.chemical.projection.chemicalproperty.ChemicalPropertySummary;
+import gov.epa.ccte.api.chemical.projection.chemicalproperty.*;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -87,5 +86,64 @@ public interface ChemicalPropertyPredictedRepository extends JpaRepository<Chemi
     			pd.prop_name, pd.prop_unit
     				""", nativeQuery = true)
     List<ChemicalPropertySummary> findSummaryByDtxsidAndPropName(@Param("dtxsid")String dtxsid, @Param("propName")String propName, @Param("propCategory")String propCategory);
+    
+    @Query(value = """
+    		SELECT
+    		    d.source_name AS sourceName,
+    		    d.source_description AS sourceDescription,
+    		    d.public_source_url AS publicSourceUrl,
+    		    d.prop_value AS propValue,
+    		    d.direct_url AS directUrl,
+    		    d.exp_details_species_latin AS speciesLatin,
+    		    d.exp_details_response_site AS responseSite,
+    		    CASE 
+    		    	WHEN d.direct_url IS NULL THEN 'Not Available'
+    		    	WHEN d.direct_url IN ('https://ochem.eu/home/show.do', 'https://www.echemportal.org/echemportal/property-search') THEN 'Not Available' 
+    		    	ELSE 'Available' 
+    		    END AS availability,
+    		    CASE 
+    		    	WHEN d.direct_url IS NULL THEN FALSE
+    		    	WHEN d.direct_url IN ('https://ochem.eu/home/show.do', 'https://www.echemportal.org/echemportal/property-search') THEN FALSE
+    		    	ELSE TRUE
+			    END AS showLink
+
+    		FROM
+    			chemprop.mv_experimental_data d
+    		WHERE
+    			d.dtxsid = :dtxsid AND d.prop_name = :propName AND  d.prop_category = :propCategory AND d.prop_value IS NOT NULL
+    				""", nativeQuery = true)
+    List<ChemicalPropertySummaryExperimental> findExpermentalSummaryByDtxsidAndPropName(@Param("dtxsid")String dtxsid, @Param("propName")String propName, @Param("propCategory")String propCategory);
+    
+    @Query(value = """
+    		SELECT
+    		    pd.source_name AS sourceName,
+    		    pd.source_description AS sourceDescription,
+    		    pd.prop_value AS propValue,
+    		    CAST('https://ctx-api-dev.ccte.epa.gov/chemical/property/model/reports/html/search/?dtxsid=' || :dtxsid || '&modelId=' || CAST(pd.model_id AS VARCHAR) AS VARCHAR) AS link,
+    		    CASE 
+    		    	WHEN r.report_html IS NULL THEN 'Not Available'
+    		    	ELSE 'Available' 
+    		    END AS linkAvailability,
+    		    CASE 
+    		    	WHEN r.report_html IS NULL THEN FALSE
+    		    	ELSE TRUE
+			    END AS showLink,
+			    pd.qmrf_url AS qmrfUrl,
+			    CASE 
+			    	WHEN pd.qmrf_url IS NULL THEN 'Not Available'
+			    	ELSE 'Available' 
+			    END AS qmrfAvailability,
+			    pd.has_qmrf AS showQmrf
+
+    		FROM
+    			chemprop.mv_predicted_data pd
+    		LEFT JOIN
+    			chemprop.mv_predicted_reports r
+    		ON
+    			pd.dtxsid = r.dtxsid AND pd.model_id = r.model_id
+    		WHERE
+    			pd.dtxsid = :dtxsid AND pd.prop_name = :propName AND  pd.prop_category = :propCategory AND pd.prop_value IS NOT NULL
+    				""", nativeQuery = true)
+    List<ChemicalPropertySummaryPredicted> findPredictedSummaryByDtxsidAndPropName(@Param("dtxsid")String dtxsid, @Param("propName")String propName, @Param("propCategory")String propCategory);
 }
 

--- a/src/main/java/gov/epa/ccte/api/chemical/web/rest/ChemicalPropertyApi.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/web/rest/ChemicalPropertyApi.java
@@ -1,9 +1,7 @@
 package gov.epa.ccte.api.chemical.web.rest;
 
 import gov.epa.ccte.api.chemical.domain.ChemicalPropertyPredicted;
-import gov.epa.ccte.api.chemical.projection.chemicalproperty.ChemicalPropertyAll;
-import gov.epa.ccte.api.chemical.projection.chemicalproperty.ChemicalPropertyNames;
-import gov.epa.ccte.api.chemical.projection.chemicalproperty.ChemicalPropertySummary;
+import gov.epa.ccte.api.chemical.projection.chemicalproperty.*;
 import gov.epa.ccte.api.chemical.web.rest.errors.HigherNumberOfIdsException;
 import io.swagger.v3.oas.annotations.*;
 import io.swagger.v3.oas.annotations.media.*;
@@ -188,6 +186,42 @@ public interface ChemicalPropertyApi {
     List<ChemicalPropertySummary> propertySummaryByDtxsidAndName(@RequestParam(value ="dtxsid", required = true) String dtxsid,
     															@RequestParam(value ="propName", required = true) String propName);
     
+	/**
+	 * {@code GET  chemical/property/summary/experimental/search/ : get list of individual property value summaries for the "dtxsid" and "propertyName".
+	 *
+	 * @param dtxsid the matching dtxsid of the property summaries to retrieve.
+	 * @param propertyName the matching propertyName of the property summaries to retrieve.
+	 * 
+	 * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the list of property summaries}.
+	 */
+	@Operation(summary = "Get experimental value summaries by dtxsid and property name (Physchem)",
+           description = "Specify the dtxsid and propertyName as parameters.")
+   @ApiResponses(value= {
+           @ApiResponse(responseCode = "200", description = "OK",  content = @Content( mediaType = "application/json",
+                   schema=@Schema(oneOf = {ChemicalPropertySummaryExperimental.class})))
+   })
+    @GetMapping(value = "chemical/property/summary/experimental/search/", produces = MediaType.APPLICATION_JSON_VALUE)
+    List<ChemicalPropertySummaryExperimental> propertySummaryExperimentalByDtxsidAndName(@RequestParam(value ="dtxsid", required = true) String dtxsid,
+    															@RequestParam(value ="propName", required = true) String propName);
+	
+	/**
+	 * {@code GET  chemical/property/summary/predicted/search/ : get list of individual property value summaries for the "dtxsid" and "propertyName".
+	 *
+	 * @param dtxsid the matching dtxsid of the property summaries to retrieve.
+	 * @param propertyName the matching propertyName of the property summaries to retrieve.
+	 * 
+	 * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the list of property summaries}.
+	 */
+	@Operation(summary = "Get predicted value summaries by dtxsid and property name (Physchem)",
+           description = "Specify the dtxsid and propertyName as parameters.")
+   @ApiResponses(value= {
+           @ApiResponse(responseCode = "200", description = "OK",  content = @Content( mediaType = "application/json",
+                   schema=@Schema(oneOf = {ChemicalPropertySummaryExperimental.class})))
+   })
+    @GetMapping(value = "chemical/property/summary/predicted/search/", produces = MediaType.APPLICATION_JSON_VALUE)
+    List<ChemicalPropertySummaryPredicted> propertySummaryPredictedByDtxsidAndName(@RequestParam(value ="dtxsid", required = true) String dtxsid,
+    															@RequestParam(value ="propName", required = true) String propName);
+	
     // *********************** Property Summary - end *************************************
     // *********************** Fate - Start *************************************
     
@@ -260,6 +294,42 @@ public interface ChemicalPropertyApi {
    })
     @GetMapping(value = "chemical/fate/summary/search/", produces = MediaType.APPLICATION_JSON_VALUE)
     List<ChemicalPropertySummary> fateSummaryByDtxsidAndName(@RequestParam(value ="dtxsid", required = true) String dtxsid,
+    															@RequestParam(value ="propName", required = true) String propName);
+	
+	/**
+	 * {@code GET  chemical/fate/summary/experimental/search/ : get list of individual property value summaries for the "dtxsid" and "propertyName".
+	 *
+	 * @param dtxsid the matching dtxsid of the property summaries to retrieve.
+	 * @param propertyName the matching propertyName of the property summaries to retrieve.
+	 * 
+	 * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the list of property summaries}.
+	 */
+	@Operation(summary = "Get experimental value summaries by dtxsid and property name (Env. Fate)",
+           description = "Specify the dtxsid and propertyName as parameters.")
+   @ApiResponses(value= {
+           @ApiResponse(responseCode = "200", description = "OK",  content = @Content( mediaType = "application/json",
+                   schema=@Schema(oneOf = {ChemicalPropertySummaryExperimental.class})))
+   })
+    @GetMapping(value = "chemical/fate/summary/experimental/search/", produces = MediaType.APPLICATION_JSON_VALUE)
+    List<ChemicalPropertySummaryExperimental> fateSummaryExperimentalByDtxsidAndName(@RequestParam(value ="dtxsid", required = true) String dtxsid,
+    															@RequestParam(value ="propName", required = true) String propName);
+	
+	/**
+	 * {@code GET  chemical/fate/summary/predicted/search/ : get list of individual property value summaries for the "dtxsid" and "propertyName".
+	 *
+	 * @param dtxsid the matching dtxsid of the property summaries to retrieve.
+	 * @param propertyName the matching propertyName of the property summaries to retrieve.
+	 * 
+	 * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the list of property summaries}.
+	 */
+	@Operation(summary = "Get predicted value summaries by dtxsid and property name (Env. Fate)",
+           description = "Specify the dtxsid and propertyName as parameters.")
+   @ApiResponses(value= {
+           @ApiResponse(responseCode = "200", description = "OK",  content = @Content( mediaType = "application/json",
+                   schema=@Schema(oneOf = {ChemicalPropertySummaryExperimental.class})))
+   })
+    @GetMapping(value = "chemical/fate/summary/predicted/search/", produces = MediaType.APPLICATION_JSON_VALUE)
+    List<ChemicalPropertySummaryPredicted> fateSummaryPredictedByDtxsidAndName(@RequestParam(value ="dtxsid", required = true) String dtxsid,
     															@RequestParam(value ="propName", required = true) String propName);
 
 }

--- a/src/main/java/gov/epa/ccte/api/chemical/web/rest/ChemicalPropertyResource.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/web/rest/ChemicalPropertyResource.java
@@ -1,9 +1,7 @@
 package gov.epa.ccte.api.chemical.web.rest;
 
 import gov.epa.ccte.api.chemical.domain.ChemicalPropertyPredicted;
-import gov.epa.ccte.api.chemical.projection.chemicalproperty.ChemicalPropertyAll;
-import gov.epa.ccte.api.chemical.projection.chemicalproperty.ChemicalPropertyNames;
-import gov.epa.ccte.api.chemical.projection.chemicalproperty.ChemicalPropertySummary;
+import gov.epa.ccte.api.chemical.projection.chemicalproperty.*;
 import gov.epa.ccte.api.chemical.repository.ChemicalPropertyExperimentalRepository;
 import gov.epa.ccte.api.chemical.repository.ChemicalPropertyPredictedRepository;
 import gov.epa.ccte.api.chemical.web.rest.errors.HigherNumberOfIdsException;
@@ -129,6 +127,26 @@ public class ChemicalPropertyResource implements ChemicalPropertyApi {
         return data;
 
     }
+    
+    @Override
+    public List<ChemicalPropertySummaryExperimental> propertySummaryExperimentalByDtxsidAndName(String dtxsid, String propName) {
+		log.info("dtxsid = {}, property name = {}", dtxsid, propName);
+		String propCategory = "Physchem";
+		List<ChemicalPropertySummaryExperimental> data =  predictedRepository.findExpermentalSummaryByDtxsidAndPropName(dtxsid, propName, propCategory);
+			
+		return data;
+
+	}
+    
+    @Override
+    public List<ChemicalPropertySummaryPredicted> propertySummaryPredictedByDtxsidAndName(String dtxsid, String propName) {
+		log.info("dtxsid = {}, property name = {}", dtxsid, propName);
+		String propCategory = "Physchem";
+		List<ChemicalPropertySummaryPredicted> data =  predictedRepository.findPredictedSummaryByDtxsidAndPropName(dtxsid, propName, propCategory);
+			
+		return data;
+
+	}
 
     // *********************** Property Summary - End *************************************
     // *********************** Fate - Start *************************************
@@ -175,5 +193,25 @@ public class ChemicalPropertyResource implements ChemicalPropertyApi {
         return data;
 
     }
+    
+    @Override
+    public List<ChemicalPropertySummaryExperimental> fateSummaryExperimentalByDtxsidAndName(String dtxsid, String propName) {
+		log.info("dtxsid = {}, property name = {}", dtxsid, propName);
+		String propCategory = "Env. Fate/transport";
+		List<ChemicalPropertySummaryExperimental> data =  predictedRepository.findExpermentalSummaryByDtxsidAndPropName(dtxsid, propName, propCategory);
+			
+		return data;
+
+	}
+    
+    @Override
+    public List<ChemicalPropertySummaryPredicted> fateSummaryPredictedByDtxsidAndName(String dtxsid, String propName) {
+		log.info("dtxsid = {}, property name = {}", dtxsid, propName);
+		String propCategory = "Env. Fate/transport";
+		List<ChemicalPropertySummaryPredicted> data =  predictedRepository.findPredictedSummaryByDtxsidAndPropName(dtxsid, propName, propCategory);
+			
+		return data;
+
+	}
     
 }


### PR DESCRIPTION
I will be providing images of the json generated by the new endpoints and the corresponding table that they will provide data for in the Dashboard. These endpoints are meant to populate the Experimental and Predicted tables under the Summary table.
*This is representing a different dataset than is currently being used by the Dashboard. there will be additional or 'missing' entries that are being resolved by the Data Team.

<img width="1833" height="951" alt="ccd-physchem-reference-page" src="https://github.com/user-attachments/assets/2438404b-0aba-453e-aa5e-43dd1ec2162d" />

/chemical/property/summary/experimental/search/?dtxsid=DTXSID7020182&propName=Boiling Point
<img width="1677" height="927" alt="ccd-physchem-experimental" src="https://github.com/user-attachments/assets/2dede93c-1e4f-42d0-b3f5-42f01e0ac8cd" />

/chemical/property/summary/predicted/search/?dtxsid=DTXSID7020182&propName=Boiling Point
<img width="1684" height="954" alt="ccd-physchem-predicted" src="https://github.com/user-attachments/assets/61628eb2-db7b-470c-89b4-9ab163deeba8" />

<img width="1776" height="866" alt="ccd-fate-reference" src="https://github.com/user-attachments/assets/d5a9a191-6f25-493d-a373-219d59aa5880" />

/chemical/fate/summary/experimental/search/?dtxsid=DTXSID7020182&propName=Bioconcentration Factor
<img width="1667" height="944" alt="ccd-fate-experimental" src="https://github.com/user-attachments/assets/b308257f-7f9a-4b76-aeda-59cc4a3e8f8f" />

/chemical/fate/summary/predicted/search/?dtxsid=DTXSID7020182&propName=Bioconcentration Factor
<img width="1689" height="946" alt="ccd-fate-predicted" src="https://github.com/user-attachments/assets/db495d33-7ece-4bc1-9f67-c9cfbde9bc12" />



