### PR TITLE
CE-4962- Updated chemical search logic by applying rank filtering

### DIFF
--- a/src/main/java/gov/epa/ccte/api/chemical/service/SearchChemicalService.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/service/SearchChemicalService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.*;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static gov.epa.ccte.api.chemical.service.ChemicalUtils.*;
 
@@ -36,16 +37,16 @@ public class SearchChemicalService {
         // Initialize values
         isThisCASRN = Arrays.asList("Alternate CAS-RN","Integrated Source CAS-RN","CASRN","FDA CAS-Like Identifier","Deleted CAS-RN");
         searchMatchWithoutInchikey = Arrays.asList("Deleted CAS-RN","PC-Code","Substance_id","Approved Name","Alternate CAS-RN",
-                "CAS-RN","Synonym","Integrated Source CAS-RN","DSSTox_Compound_Id","Systematic Name","Integrated Source Name",
-                "Expert Validated Synonym","Synonym from Valid Source","FDA CAS-Like Identifier","DSSTox_Substance_Id", "EHCA Number", "EC Number");
+                "CAS-RN","Synonym","DSSTox_Compound_Id","Systematic Name","Integrated Source Name",
+                "Expert Validated Synonym","Synonym from Valid Source","FDA CAS-Like Identifier","DSSTox_Substance_Id", "ECHA Number", "EC Number");
         searchMatchWithInchikey = Arrays.asList("Deleted CAS-RN","PC-Code","Substance_id","Approved Name","Alternate CAS-RN",
-                "CAS-RN","Synonym","Integrated Source CAS-RN","DSSTox_Compound_Id","Systematic Name","Integrated Source Name",
+                "CAS-RN","Synonym","DSSTox_Compound_Id","Systematic Name","Integrated Source Name",
                 "Expert Validated Synonym","Synonym from Valid Source","FDA CAS-Like Identifier","DSSTox_Substance_Id",
-                "InChIKey", "Indigo InChIKey", "EHCA Number", "EC Number");
+                "InChIKey", "Indigo InChIKey", "ECHA Number", "EC Number");
         searchNames4SingleSearch = Arrays.asList("Deleted CAS-RN","PC-Code","Approved Name","Alternate CAS-RN","CAS-RN",
-                "CASRN","Synonym","Integrated Source CAS-RN","DSSTox_Compound_Id","Systematic Name","Integrated Source Name",
+                "CASRN","Synonym","DSSTox_Compound_Id","Systematic Name","Integrated Source Name",
                 "Expert Validated Synonym","Synonym from Valid Source","FDA CAS-Like Identifier","DSSTox_Substance_Id",
-                "EHCA Number", "EC Number", "InChIKey", "Indigo InChIKey");
+                "ECHA Number", "EC Number", "InChIKey", "Indigo InChIKey");
     }
 
 
@@ -402,7 +403,54 @@ public class SearchChemicalService {
         log.debug("{} records match for {}", searchResult.size(), word);
 
         searchResult = removeDuplicates(searchResult);
+        searchResult = applyStartWithRankFilter(searchResult);
         return searchResult;
+    }
+    
+    /**
+     * Applies rank filtering for the "start-with" search.
+     * Keeps all ranks < 16 if any exist, otherwise keeps rank = 16.
+     */
+    public List<ChemicalSearchAll> applyStartWithRankFilter(List<ChemicalSearchAll> results) {
+        if (results == null || results.isEmpty()) return results;
+
+        int minRank = results.stream()
+                .mapToInt(ChemicalSearchAll::getRank)
+                .min()
+                .orElse(Integer.MAX_VALUE);
+
+        if (minRank < 16) {
+            // Keep all verified ranks (1–15)
+            return results.stream()
+                    .filter(r -> r.getRank() < 16)
+                    .collect(Collectors.toList());
+        } else {
+            // Only integrated source names exist (rank 16)
+            return results.stream()
+                    .filter(r -> r.getRank() == 16)
+                    .collect(Collectors.toList());
+        }
+    }
+    
+    public List<CcdChemicalSearchResult> applyRankFilterSearchResult(List<CcdChemicalSearchResult> results) {
+        if (results == null || results.isEmpty()) return results;
+
+        int minRank = results.stream()
+                .mapToInt(CcdChemicalSearchResult::getRank)
+                .min()
+                .orElse(Integer.MAX_VALUE);
+
+        if (minRank < 16) {
+            // Keep all verified ranks (1–15)
+            return results.stream()
+                    .filter(r -> r.getRank() < 16)
+                    .collect(Collectors.toList());
+        } else {
+            // Only integrated source names exist (rank 16)
+            return results.stream()
+                    .filter(r -> r.getRank() == 16)
+                    .collect(Collectors.toList());
+        }
     }
 
     private List<ChemicalSearchAll> getStartWithFromDB(String searchWord, List<String> searchMatchValues, Integer top) {
@@ -436,7 +484,8 @@ public class SearchChemicalService {
             case "chemicalsearchall": {
                  // ChemicalSearchAll.class
                 List result = getContainFromDB1(searchWord, top, ChemicalSearchAll.class);
-                return removeDuplicates(result);
+                List filteredResult = applyStartWithRankFilter((List<ChemicalSearchAll>)result);
+                return removeDuplicates(filteredResult);
             }
             case "dtxsidonly":{
                 // DtxsidOnly.class

--- a/src/main/java/gov/epa/ccte/api/chemical/web/rest/ChemicalSearchResource.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/web/rest/ChemicalSearchResource.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.RestController;
 
+import gov.epa.ccte.api.chemical.projection.search.CcdChemicalSearchResult;
 import gov.epa.ccte.api.chemical.projection.search.ChemicalBatchSearchResult;
 import gov.epa.ccte.api.chemical.projection.search.ChemicalSearchAll;
 import gov.epa.ccte.api.chemical.projection.search.ChemicalSearchInternal;
@@ -56,6 +57,7 @@ public class ChemicalSearchResource implements ChemicalSearchApi {
             case "chemicalsearchall":
                 searchResult = searchRepository.findByModifiedValueOrderByRankAsc(searchWord, ChemicalSearchAll.class);
                 searchResult = chemicalService.removeDuplicates(searchResult);
+                searchResult = chemicalService.applyStartWithRankFilter((List<ChemicalSearchAll>)searchResult);
                 break;
             case "dtxsidonly":
                 searchResult = searchRepository.findByModifiedValueOrderByRankAsc(searchWord, DtxsidOnly.class);
@@ -64,6 +66,7 @@ public class ChemicalSearchResource implements ChemicalSearchApi {
             case "ccdsearchresult":
                 searchResult = searchRepository.equalCcd(searchWord);
                 searchResult = chemicalService.removeDuplicates(searchResult);
+                searchResult = chemicalService.applyRankFilterSearchResult((List<CcdChemicalSearchResult>)searchResult);
                 break;
         }
         if (searchResult == null || searchResult.isEmpty())


### PR DESCRIPTION
CE-4962- Updated chemical search logic by applying ran filtering (min(rank)> 16) rule.

Refer this comment from Charlie on https://jira.epa.gov/browse/CE-4962

![Uploading image.png…]()
