### PR TITLE
CE-4994 Fix the sort order of returned synonyms by Rank #272

### DIFF
--- a/src/main/java/gov/epa/ccte/api/chemical/projection/ChemicalSynonymAll.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/projection/ChemicalSynonymAll.java
@@ -2,27 +2,39 @@ package gov.epa.ccte.api.chemical.projection;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.beans.factory.annotation.Value;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 
 /**
  * A Projection for the {@link gov.epa.ccte.api.chemical.domain.ChemicalSynonym} entity
  */
+@JsonPropertyOrder({
+    "dtxsid",
+    "valid",
+    "good",
+    "other",
+    "deleted",
+    "beilstein",
+    "alternate",
+    "pcCode"
+})
 @Schema(name = "ChemicalSynonymAll", description = "Different types of synonyms for request dtxsid")
 public interface ChemicalSynonymAll {
 
     String getDtxsid();
-    String getPcCode();
-    @Value("#{target.ValidSynonym == null? null : target.ValidSynonym.split(\"\\|\")}")
+    @Value("#{target.ValidSynonym == null? null : target.ValidSynonym.split('\\|')}")
     String[] getValid();
-    @Value("#{target.GoodSynonyms == null? null : target.GoodSynonyms.split(\"\\|\")}")
+    @Value("#{target.GoodSynonyms == null? null : target.GoodSynonyms.split('\\|')}")
     String[] getGood();
-    @Value("#{target.DeletedSynonyms == null? null : target.DeletedSynonyms.split(\"\\|\")}")
-    String[] getDeletedCasrn();
-    @Value("#{target.OtherSynonyms == null? null : target.OtherSynonyms.split(\"\\|\")}")
+    @Value("#{target.DeletedSynonyms == null? null : target.DeletedSynonyms.split('\\|')}")
     String[] getOther();
-    @Value("#{target.BeilsteinSynonyms == null? null : target.BeilsteinSynonyms.split(\"\\|\")}")
+    @Value("#{target.BeilsteinSynonyms == null? null : target.BeilsteinSynonyms.split('\\|')}")
+    String[] getDeleted();
+    @Value("#{target.OtherSynonyms == null? null : target.OtherSynonyms.split('\\|')}")
     String[] getBeilstein();
-    @Value("#{target.AlternateSynonyms == null? null : target.AlternateSynonyms.split(\"\\|\")}")
-    String[] getAlternateCasrn();
-        
+    @Value("#{target.AlternateSynonyms == null? null : target.AlternateSynonyms.split('\\|')}")
+    String[] getAlternate();
+    @Value("#{target.PcCode == null? null : target.PcCode.split('\\|')}")
+    String[] getPcCode();
+
 }

--- a/src/main/java/gov/epa/ccte/api/chemical/repository/ChemicalSynonymRepository.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/repository/ChemicalSynonymRepository.java
@@ -26,18 +26,20 @@ public interface ChemicalSynonymRepository extends JpaRepository<ChemicalSynonym
     <T> List<T> findByDtxsidInAndIsPublicOrderByDtxsidAsc(Collection<String> dtxsids, Boolean isPublic, Class<T> type);
     
     @Query(nativeQuery = true,
-            value = "SELECT unnest(string_to_array(valid_synonym, '|')) AS synonym, 'valid_synonym' AS quality FROM ch.v_chemical_snonyms WHERE dtxsid = :dtxsid " +
-                    "UNION ALL " +
-                    "SELECT unnest(string_to_array(good_synonym, '|')) AS synonym, 'good_synonym' AS quality FROM ch.v_chemical_snonyms WHERE dtxsid = :dtxsid " +
-                    "UNION ALL " +
-                    "SELECT unnest(string_to_array(deleted_synonym, '|')) AS synonym, 'deleted_synonym' AS quality FROM ch.v_chemical_snonyms WHERE dtxsid = :dtxsid " +
-                    "UNION ALL " +
-                    "SELECT unnest(string_to_array(other_synonym, '|')) AS synonym, 'other_synonym' AS quality FROM ch.v_chemical_snonyms WHERE dtxsid = :dtxsid " +
-                    "UNION ALL " +
-                    "SELECT unnest(string_to_array(beilstein_synonym, '|')) AS synonym, 'beilstein_synonym' AS quality FROM ch.v_chemical_snonyms WHERE dtxsid = :dtxsid " +
-                    "UNION ALL " +
-                    "SELECT unnest(string_to_array(alternate_synonym, '|')) AS synonym, 'alternate_synonym' AS quality FROM ch.v_chemical_snonyms WHERE dtxsid = :dtxsid")
+    	    value = "SELECT unnest(string_to_array(valid_synonym, '|')) AS synonym, 'valid_synonym' AS quality, 1 AS rank FROM ch.v_chemical_snonyms WHERE dtxsid = :dtxsid " +
+    	            "UNION ALL " +
+    	            "SELECT unnest(string_to_array(good_synonym, '|')) AS synonym, 'good_synonym' AS quality, 2 AS rank FROM ch.v_chemical_snonyms WHERE dtxsid = :dtxsid " +
+    	            "UNION ALL " +
+    	            "SELECT unnest(string_to_array(other_synonym, '|')) AS synonym, 'other_synonym' AS quality, 3 AS rank FROM ch.v_chemical_snonyms WHERE dtxsid = :dtxsid " +
+    	            "UNION ALL " +
+    	            "SELECT unnest(string_to_array(deleted_synonym, '|')) AS synonym, 'deleted_synonym' AS quality, 4 AS rank FROM ch.v_chemical_snonyms WHERE dtxsid = :dtxsid " +
+    	            "UNION ALL " +
+    	            "SELECT unnest(string_to_array(beilstein_synonym, '|')) AS synonym, 'beilstein_synonym' AS quality, 5 AS rank FROM ch.v_chemical_snonyms WHERE dtxsid = :dtxsid " +
+    	            "UNION ALL " +
+    	            "SELECT unnest(string_to_array(alternate_synonym, '|')) AS synonym, 'alternate_synonym' AS quality, 6 AS rank FROM ch.v_chemical_snonyms WHERE dtxsid = :dtxsid " +
+            		"ORDER BY rank ASC")
      List<CcdSynonymFlatProjection> getFlatSynonymsByDtxsid(@Param("dtxsid") String dtxsid);
     
+
 
 }

--- a/src/main/java/gov/epa/ccte/api/chemical/repository/ChemicalSynonymRepository.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/repository/ChemicalSynonymRepository.java
@@ -37,9 +37,12 @@ public interface ChemicalSynonymRepository extends JpaRepository<ChemicalSynonym
     	            "SELECT unnest(string_to_array(beilstein_synonym, '|')) AS synonym, 'beilstein_synonym' AS quality, 5 AS rank FROM ch.v_chemical_snonyms WHERE dtxsid = :dtxsid " +
     	            "UNION ALL " +
     	            "SELECT unnest(string_to_array(alternate_synonym, '|')) AS synonym, 'alternate_synonym' AS quality, 6 AS rank FROM ch.v_chemical_snonyms WHERE dtxsid = :dtxsid " +
+		       	    "UNION ALL " +
+    	            "SELECT unnest(string_to_array(pc_code, '|')) AS synonym, 'pc_code' AS quality, 7 AS rank FROM ch.v_chemical_snonyms WHERE dtxsid = :dtxsid " +
             		"ORDER BY rank ASC")
      List<CcdSynonymFlatProjection> getFlatSynonymsByDtxsid(@Param("dtxsid") String dtxsid);
     
 
 
 }
+

--- a/src/test/java/gov/epa/ccte/api/chemical/web/rest/ChemicalSynonymResourceTest.java
+++ b/src/test/java/gov/epa/ccte/api/chemical/web/rest/ChemicalSynonymResourceTest.java
@@ -48,7 +48,7 @@ public class ChemicalSynonymResourceTest {
     private static class ChemicalSynonymAllMock implements ChemicalSynonymAll {
         // Fields
     	private String dtxsid;
-        private String pcCode;
+        private String[] pcCode;
         private String[] valid;
         private String[] good;
         private String[] deletedCasrn;
@@ -56,7 +56,7 @@ public class ChemicalSynonymResourceTest {
         private String[] beilstein;
         private String[] alternateCasrn;
         // Constructor
-        public ChemicalSynonymAllMock(String dtxsid, String pcCode, String[] valid, String[] good, String[] deletedCasrn, String[] other, String[] beilstein, String[] alternateCasrn) {
+        public ChemicalSynonymAllMock(String dtxsid, String pcCode[], String[] valid, String[] good, String[] deletedCasrn, String[] other, String[] beilstein, String[] alternateCasrn) {
             this.dtxsid = dtxsid;
             this.pcCode = pcCode;
             this.valid = valid;
@@ -68,13 +68,13 @@ public class ChemicalSynonymResourceTest {
         }
         // Getters
         @Override public String getDtxsid() { return dtxsid; }
-        @Override public String getPcCode() { return pcCode; }
+        @Override public String[] getPcCode() { return pcCode; }
         @Override public String[] getValid() { return valid; }
         @Override public String[] getGood() { return good; }
-        @Override public String[] getDeletedCasrn() { return deletedCasrn; }
+        @Override public String[] getDeleted() { return deletedCasrn; }
         @Override public String[] getOther() { return other; }
         @Override public String[] getBeilstein() { return beilstein; }
-        @Override public String[] getAlternateCasrn() { return alternateCasrn; }
+        @Override public String[] getAlternate() { return alternateCasrn; }
 
     }
 


### PR DESCRIPTION
A JsonPropertyOrder annotation was added to the SynonymAll projection to ensure that the return variables return in the same order every single time. they data type was also fixed for pc_code to get rid of NULL returns. the corresponding resource tests was updated to match data types. 