### PR TITLE
Add 'label' column back into Lists #302

### DIFF
--- a/src/main/java/gov/epa/ccte/api/chemical/domain/ChemicalList.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/domain/ChemicalList.java
@@ -28,6 +28,10 @@ public class ChemicalList {
     private String listName;
 
     @Size(max = 50)
+    @Column(name = "label", length = 50)
+    private String label;
+    
+    @Size(max = 50)
     @Column(name = "type", length = 50)
     private String type;
     

--- a/src/main/java/gov/epa/ccte/api/chemical/projection/chemicallist/ChemicalListWithDtxsids.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/projection/chemicallist/ChemicalListWithDtxsids.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonPropertyOrder({
     "id",
 	"listName",
+	"label",
 	"type",
 	"shortDescription",
 	"longDescription",
@@ -23,6 +24,7 @@ public interface ChemicalListWithDtxsids {
 	
     Integer getId();
     String getListName();
+    String getLabel();
     String getType();
     String getShortDescription();
     String getLongDescription();
@@ -32,6 +34,7 @@ public interface ChemicalListWithDtxsids {
     
     Void setid(Integer id);
     Void setListName(String listName);
+    Void setLabel(String label);
     Void setType(String type);
     Void setShortDescription(String shortDescription);
     Void setLongDescription(String longDescription);

--- a/src/main/java/gov/epa/ccte/api/chemical/repository/ChemicalListRepository.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/repository/ChemicalListRepository.java
@@ -42,6 +42,7 @@ public interface ChemicalListRepository extends JpaRepository<ChemicalList, Inte
     @Query( nativeQuery = true, value = """
     				SELECT 
     					l.list_name as listName, 
+    					l.label,
 					    l.type, 
 					    l.short_description as shortDescription, 
 					    l.long_description as longDescription, 
@@ -58,7 +59,7 @@ public interface ChemicalListRepository extends JpaRepository<ChemicalList, Inte
 					WHERE 
 					    upper(l.list_name) = upper(:listName)
                     GROUP BY 
-    		            l.list_name, l.type, l.short_description, l.long_description, l.chemical_count, l.updated_at, l.id
+    		            l.list_name, l.type, l.label, l.short_description, l.long_description, l.chemical_count, l.updated_at, l.id
                     
     		    """)
     List<ChemicalListWithDtxsids> getListWithDtxsidsByListName(String listName);
@@ -66,7 +67,8 @@ public interface ChemicalListRepository extends JpaRepository<ChemicalList, Inte
     @Transactional(readOnly = true)
     @Query( nativeQuery = true, value = """
     				SELECT 
-    					l.list_name as listName, 
+    					l.list_name as listName,
+    					l.label, 
 					    l.type, 
 					    l.short_description as shortDescription, 
 					    l.long_description as longDescription, 
@@ -83,7 +85,7 @@ public interface ChemicalListRepository extends JpaRepository<ChemicalList, Inte
 					WHERE 
 						l.type = :type 
 					GROUP BY 
-						l.list_name, l.type, l.short_description, l.long_description, l.chemical_count, l.updated_at, l.id
+						l.list_name, l.type, l.label, l.short_description, l.long_description, l.chemical_count, l.updated_at, l.id
 					Order BY 
 					   l.list_name
 				""")
@@ -92,7 +94,8 @@ public interface ChemicalListRepository extends JpaRepository<ChemicalList, Inte
     @Transactional(readOnly = true)
     @Query( nativeQuery = true, value = """
             		SELECT 
-            		    l.list_name as listName, 
+            		    l.list_name as listName,
+            		    l.label, 
             		    l.type, l.short_description as shortDescription, 
             		    l.long_description as longDescription, 
             		    l.chemical_count as chemicalCount,
@@ -106,7 +109,7 @@ public interface ChemicalListRepository extends JpaRepository<ChemicalList, Inte
                     ON
                        l.id = c.list_id
                     GROUP BY 
-                       l.list_name, l.type, l.short_description, l.long_description, l.chemical_count,l.updated_at, l.id
+                       l.list_name, l.type, l.label, l.short_description, l.long_description, l.chemical_count,l.updated_at, l.id
                     Order BY 
 					   l.type, l.list_name
                 """)
@@ -119,6 +122,7 @@ public interface ChemicalListRepository extends JpaRepository<ChemicalList, Inte
 			        SELECT DISTINCT ON (l.list_name)
 			        	l.id,
 			            l.list_name,
+			            l.label,
 			            l.type,
 			            l.short_description,
 			            l.long_description,
@@ -163,6 +167,7 @@ public interface ChemicalListRepository extends JpaRepository<ChemicalList, Inte
 		    FROM (
 		        SELECT DISTINCT ON (l.list_name)
 		            l.list_name,
+		            l.label,
 		            l.type,
 		            l.short_description,
 		            l.long_description,


### PR DESCRIPTION
The 'label' column has been added back into Chemical Lists, but the values are currently all NULL. Data will need to repopulate the table.