### PR TITLE
Switch chemical list query by name with dtxsids back to Optional #304

### DIFF
--- a/src/main/java/gov/epa/ccte/api/chemical/domain/ChemicalList.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/domain/ChemicalList.java
@@ -1,5 +1,6 @@
 package gov.epa.ccte.api.chemical.domain;
 
+import gov.epa.ccte.api.chemical.projection.chemicallist.ChemicalListBase;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
@@ -17,7 +18,7 @@ import java.time.Instant;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "v_chemical_lists_new", schema = "ch")
-public class ChemicalList {
+public class ChemicalList implements ChemicalListBase {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)

--- a/src/main/java/gov/epa/ccte/api/chemical/projection/chemicallist/ChemicalListBase.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/projection/chemicallist/ChemicalListBase.java
@@ -1,0 +1,4 @@
+package gov.epa.ccte.api.chemical.projection.chemicallist;
+
+public interface ChemicalListBase {
+}

--- a/src/main/java/gov/epa/ccte/api/chemical/projection/chemicallist/ChemicalListName.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/projection/chemicallist/ChemicalListName.java
@@ -3,7 +3,7 @@ package gov.epa.ccte.api.chemical.projection.chemicallist;
 /**
  * Projection for {@link gov.epa.ccte.api.chemical.domain.ChemicalList}
  */
-public interface ChemicalListName {
+public interface ChemicalListName extends ChemicalListBase{
 	
     String getListName();
     

--- a/src/main/java/gov/epa/ccte/api/chemical/projection/chemicallist/ChemicalListWithDtxsids.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/projection/chemicallist/ChemicalListWithDtxsids.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 	"updatedAt",
 	"dtxsids"
 })
-public interface ChemicalListWithDtxsids {
+public interface ChemicalListWithDtxsids extends ChemicalListBase {
 	
     Integer getId();
     String getListName();

--- a/src/main/java/gov/epa/ccte/api/chemical/repository/ChemicalListRepository.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/repository/ChemicalListRepository.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 @RepositoryRestResource(exported = false)
 public interface ChemicalListRepository extends JpaRepository<ChemicalList, Integer> {
@@ -27,7 +28,7 @@ public interface ChemicalListRepository extends JpaRepository<ChemicalList, Inte
 
 
     @Transactional(readOnly = true)
-    <T>List<T> findByListNameIgnoreCase(String listName, Class<T> type);
+    Optional<ChemicalList> findByListNameIgnoreCase(String listName);
 
     @Transactional(readOnly = true)
     <T>List<T> findByListNameInIgnoreCaseOrderByListNameAsc(Collection<String> listNames, Class<T> type);
@@ -62,7 +63,7 @@ public interface ChemicalListRepository extends JpaRepository<ChemicalList, Inte
     		            l.list_name, l.type, l.label, l.short_description, l.long_description, l.chemical_count, l.updated_at, l.id
                     
     		    """)
-    List<ChemicalListWithDtxsids> getListWithDtxsidsByListName(String listName);
+    Optional<ChemicalListWithDtxsids> getListWithDtxsidsByListName(String listName);
 
     @Transactional(readOnly = true)
     @Query( nativeQuery = true, value = """

--- a/src/main/java/gov/epa/ccte/api/chemical/web/rest/ChemicalListApi.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/web/rest/ChemicalListApi.java
@@ -52,7 +52,7 @@ public interface ChemicalListApi {
                     schema=@Schema(oneOf = {ChemicalList.class, ChemicalListWithDtxsids.class})))
     })
     @GetMapping(value = "/search/by-name/{listName}")
-    List<?> listByName(@Parameter(required = true, description = "Chemical List Name", example = "40CFR1164") @PathVariable String listName,
+    ChemicalListBase listByName(@Parameter(required = true, description = "Chemical List Name", example = "40CFR1164") @PathVariable String listName,
                                 @RequestParam(value = "projection", required = false, defaultValue = "chemicallistall") ChemicalListProjection projection);
 
     @Operation(summary = "Get public lists by dtxsid")

--- a/src/main/java/gov/epa/ccte/api/chemical/web/rest/ChemicalListResource.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/web/rest/ChemicalListResource.java
@@ -2,6 +2,7 @@ package gov.epa.ccte.api.chemical.web.rest;
 
 import gov.epa.ccte.api.chemical.domain.ChemicalList;
 import gov.epa.ccte.api.chemical.projection.chemicallist.*;
+import gov.epa.ccte.api.chemical.web.rest.errors.IdentifierNotFoundException;
 import gov.epa.ccte.api.chemical.repository.ChemicalListRepository;
 import gov.epa.ccte.api.chemical.repository.ChemicalListChemicalRepository;
 import gov.epa.ccte.api.chemical.service.SearchChemicalService;
@@ -53,11 +54,11 @@ public class ChemicalListResource implements ChemicalListApi {
     }
 
     @Override
-    public List<?> listByName(String listName, ChemicalListProjection projection) {
+    public ChemicalListBase listByName(String listName, ChemicalListProjection projection) {
         log.debug("list name={}", listName);
         return switch (projection) {
-            case chemicallistall -> listRepository.findByListNameIgnoreCase(listName, ChemicalList.class);
-            case chemicallistwithdtxsids -> listRepository.getListWithDtxsidsByListName(listName);
+            case chemicallistall -> listRepository.findByListNameIgnoreCase(listName).orElseThrow(() -> new IdentifierNotFoundException("List name", listName));
+            case chemicallistwithdtxsids -> listRepository.getListWithDtxsidsByListName(listName).orElseThrow(() -> new IdentifierNotFoundException("List name", listName));
             default -> null;
         };
     }

--- a/src/test/java/gov/epa/ccte/api/chemical/web/rest/ChemicalListResourceTest.java
+++ b/src/test/java/gov/epa/ccte/api/chemical/web/rest/ChemicalListResourceTest.java
@@ -203,9 +203,9 @@ public class ChemicalListResourceTest {
     
     @Test
     void testGetChemicalListsByName() throws Exception {
-		final List<Object> lists = Collections.singletonList(chemicalList);
+		final Optional<ChemicalList> lists = Optional.of(chemicalList);
 		
-		when(listRepository.findByListNameIgnoreCase(eq("BIOSOLIDS"), any())).thenReturn(lists);
+		when(listRepository.findByListNameIgnoreCase(eq("BIOSOLIDS"))).thenReturn(lists);
 		
 		mockMvc.perform(get("/chemical/list/search/by-name/{name}", "BIOSOLIDS"))
 				.andDo(MockMvcResultHandlers.print())
@@ -216,9 +216,9 @@ public class ChemicalListResourceTest {
    
     @Test
     void testGetChemicalListsByNameProjection() throws Exception {
-		final List<ChemicalList> lists = Collections.singletonList(chemicalList);
+		final Optional<ChemicalList> lists = Optional.of(chemicalList);
 		
-		when(listRepository.findByListNameIgnoreCase("BIOSOLIDS", ChemicalList.class)).thenReturn(lists);
+		when(listRepository.findByListNameIgnoreCase("BIOSOLIDS")).thenReturn(lists);
 		
 		mockMvc.perform(get("/chemical/list/search/by-name/{name}", "BIOSOLIDS")
 				.param("projection", "chemicallistall"))
@@ -230,7 +230,7 @@ public class ChemicalListResourceTest {
    
     @Test
     void testGetChemicalListsWithDtxsidsByName() throws Exception {
-		final List<ChemicalListWithDtxsids> lists = Collections.singletonList(listWithDtxsids);
+		final Optional<ChemicalListWithDtxsids> lists = Optional.of(listWithDtxsids);
 		
 		when(listRepository.getListWithDtxsidsByListName("ACSREAG")).thenReturn(lists);
 		


### PR DESCRIPTION
I did a full comparison of theses outputs vs. the ones currently in Staging. Everything that needed to switch back to Optional has been and everything matches.
This is what it will be with these changes:
<img width="914" height="548" alt="local-by-name" src="https://github.com/user-attachments/assets/34b3ef85-18f6-4f2d-8e26-300e8dd6fa13" />
This is what it was on DEV:
<img width="908" height="589" alt="dev-by-name" src="https://github.com/user-attachments/assets/fa6c79bf-ab92-44e0-8d8f-9173dafd12d6" />
This is what was working on STG:
<img width="903" height="519" alt="stg-by-name" src="https://github.com/user-attachments/assets/11d1edc0-413d-40e0-9076-1a60056da2ca" />

