### PR TITLE
Update ApiKeyRequestFilter.java

### DIFF
--- a/src/main/java/gov/epa/ccte/api/chemical/security/ApiKeyRequestFilter.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/security/ApiKeyRequestFilter.java
@@ -135,7 +135,7 @@ public class ApiKeyRequestFilter extends GenericFilterBean {
 
         log.debug("method = {}, origin = {}, x-forwarded-server = {}, host = {}, referer ={}, refererdHost = {}, path={} ",method, origin, server, host, referer, refererdHost, path);
 
-        // if path contains exceptions - allow access to images, api health check,  model reports html, model files - without any api key
+        // if path contains exceptions - allow access to images, api health check, model reports html, model files - without any api key
         if(path.contains("/chemical/file/") || path.contains("/chemical/health") || path.contains("/chemical/property/model/reports/html/") || path.contains("/chemical/property/model/file/")){
             log.debug("skipping api-key check");
             return false;

--- a/src/main/java/gov/epa/ccte/api/chemical/security/ApiKeyRequestFilter.java
+++ b/src/main/java/gov/epa/ccte/api/chemical/security/ApiKeyRequestFilter.java
@@ -135,8 +135,8 @@ public class ApiKeyRequestFilter extends GenericFilterBean {
 
         log.debug("method = {}, origin = {}, x-forwarded-server = {}, host = {}, referer ={}, refererdHost = {}, path={} ",method, origin, server, host, referer, refererdHost, path);
 
-        // if chemical/file path - allow access to images without any api key
-        if(path.contains("/chemical/file/") || path.contains("/chemical/health")){
+        // if path contains exceptions - allow access to images, api health check,  model reports html, model files - without any api key
+        if(path.contains("/chemical/file/") || path.contains("/chemical/health") || path.contains("/chemical/property/model/reports/html/") || path.contains("/chemical/property/model/file/")){
             log.debug("skipping api-key check");
             return false;
         }


### PR DESCRIPTION
This is the finished the fix for CCD UI redirect issue. It will exempt these 2 endpoints from key requirements for HTML/image redirects. All associated data has been confirmed as 100% public.

/chemical/property/model/reports/html/search/?dtxsid=___&modelId=___
/chemical/property/model/file/search/?modelId=___&typeId=___
 